### PR TITLE
modified /done command to accept repeat requests

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -1,78 +1,17 @@
 function doPost(e) { // catches slack slash commands
   if (typeof e !== 'undefined') {
     
-    /// declare variables
-    var globvar = globalVariables();
-    var teamid_true =  globvar['TEAM_ID'];
-    var token_true = PropertiesService.getScriptProperties().getProperty('VERIFICATION_TOKEN'); // expected verification token that accompanies slack API request
-    
     // extract message body
-    var par = e.parameter;
+    var par = e.parameter; 
     
-    // ensure doPost request originates from our slack app - verification token method
-    // note: This is not as secure as using the signed secret method (https://api.slack.com/docs/verifying-requests-from-slack) because the token is not uniquely hashed and can be intercepted. 
-    // note-continued: Think of improving this in the future.
-    var token = par.token;
-  
-    if(!token_true){ // check that token_true has been set in script properties
-      return ContentService.createTextOutput('error: VERIFICATION_TOKEN is not set in script properties. The command will not run. Please contact the web app developer.');
+    // decide the nature of the POST request
+    var payload = par.payload;
+    if (payload){ // if payload exists, this is a POST request from a slack interactive component
+      return handleSlackInteractiveMessages(JSON.parse(payload));
+    } else{ // else, this is a POST request from a slack slash command
+      return(handleSlackCommands(par));
     }
-    if (token !== token_true) {
-      return ContentService.createTextOutput('error: Invalid token '+token+' . The command will not run. Please contact the web app developer.');
-    }
-    
-    // extract relevant data from message body
-    var workspace = par.team_id;
-    var command = par.command;
-    var channelid = par.channel_id;
-    var userid = par.user_id;
-    var username = par.user_name;
-    var args = par.text;
-    var response_url = par.response_url;
-   
-    // check request originates from our slack workspace
-    if (workspace != teamid_true){
-      return ContentService.createTextOutput('error: You are sending your command from an unauthorised slack workspace.');
-    }
-    
-    // process command field. 
-    // note: Slack has a 3 second timeout on client end. This has not been an issue yet, but with database volume increase, function execution times may increase and lead to timeouts. 
-    // note-continued: A fix would be to return an acknowledgement message to client directly without actually executing the function. 
-    // note-continued: The function should be somehow queued for execution and par.response_url is passed as an extra argument which allows the slack acknowledgment message to be updated. 
-    // note-continued : I have tried delayed function executes with time-delay triggers but that was not appropriate as time-delay triggers - upon creation - have a 1 min queue time before triggering. Too long.
-    // note-continued : A workaround could be to queue commands with an automatic submission to a dedicated form (see https://stackoverflow.com/questions/54809366/how-to-send-delayed-response-slack-api-with-google-apps-script-webapp?rq=1). 
-    // note-continued : The form responses must be linked to the spreadsheet. Then, the onFormSubmit installed trigger may catch the submissions and execute the relevant functions. This is faster than time-delayed triggers, but can still take several seconds. 
-    // note-continued : For now I have avoided any delayed execution and optimised the function execution times to ensure that a return message arrives within the 3 second timeout window.
-    if (command == '/_volunteer'){
-      return volunteer(args, channelid, userid, username);      
-    } else if (command == '/_volunteer2'){
-      return volunteer2(args, channelid, userid, username);      
-    } else if (command == '/_assign'){
-      return assign(args,channelid, userid);      
-    } else if (command == '/_cancel') {
-      return cancel(args, channelid, userid);
-    } else if (command == '/_done') {
-      return done(args, channelid, userid);
-    } else if (command == '/_list') {
-      return list(channelid);
-    }  else if (command == '/_listactive') {
-      return listactive(channelid);
-    } else if (command == '/_listall') {
-      return listall(channelid);
-    } else if (command == '/_listmine') {
-      return listmine(channelid,userid);
-    } else if (command == '/_listallmine') {
-      return listallmine(channelid,userid);
-    } else if (command == '/jb_v'){
-      return volunteer(args, channelid, userid, username);      
-    } else if (command == '/jb_c') {
-      return cancel(args, channelid, userid);
-    } else if (command == '/jb_d') {
-      return done(args, channelid, userid);
-    } else {
-      return ContentService.createTextOutput('error: Sorry, the `' + command + '` command is not currently supported.');
-    }
-    
+        
   }
 }
 

--- a/main.gs
+++ b/main.gs
@@ -9,55 +9,10 @@ function doPost(e) { // catches slack slash commands
     if (payload){ // if payload exists, this is a POST request from a slack interactive component
       return handleSlackInteractiveMessages(JSON.parse(payload));
     } else{ // else, this is a POST request from a slack slash command
-      return handleSlackCommands(par);        
-  }
-    
-   
-    // process command field. 
-    // note: Slack has a 3 second timeout on client end. This has not been an issue yet, but with database volume increase, function execution times may increase and lead to timeouts. 
-    // note-continued: A fix would be to return an acknowledgement message to client directly without actually executing the function. 
-    // note-continued: The function should be somehow queued for execution and par.response_url is passed as an extra argument which allows the slack acknowledgment message to be updated. 
-    // note-continued : I have tried delayed function executes with time-delay triggers but that was not appropriate as time-delay triggers - upon creation - have a 1 min queue time before triggering. Too long.
-    // note-continued : A workaround could be to queue commands with an automatic submission to a dedicated form (see https://stackoverflow.com/questions/54809366/how-to-send-delayed-response-slack-api-with-google-apps-script-webapp?rq=1). 
-    // note-continued : The form responses must be linked to the spreadsheet. Then, the onFormSubmit installed trigger may catch the submissions and execute the relevant functions. This is faster than time-delayed triggers, but can still take several seconds. 
-    // note-continued : For now I have avoided any delayed execution and optimised the function execution times to ensure that a return message arrives within the 3 second timeout window.
-    if (command == '/_volunteer'){
-      return volunteer(args, channelid, userid, username);      
-    } else if (command == '/_volunteer2'){
-      return volunteer2(args, channelid, userid, username);      
-    } else if (command == '/_assign'){
-      return assign(args,channelid, userid);      
-    } else if (command == '/_cancel') {
-      return cancel(args, channelid, userid);
-    } else if (command == '/_done') {
-      return done(args, channelid, userid);
-    } else if (command == '/_list') {
-      return list(channelid);
-    }  else if (command == '/_listactive') {
-      return listactive(channelid);
-    } else if (command == '/_listall') {
-      return listall(channelid);
-    } else if (command == '/_listmine') {
-      return listmine(channelid,userid);
-    } else if (command == '/_listallmine') {
-      return listallmine(channelid,userid);
-    } else if (command == '/jb_v'){
-      return volunteer(args, channelid, userid, username);      
-    } else if (command == '/jb_c') {
-      return cancel(args, channelid, userid);
-    } else if (command == '/jb_d') {
-      return done(args, channelid, userid);
-    // IB dev switch
-    } else if (command == '/ib_v'){
-      return volunteer(args, channelid, userid, username);      
-    } else if (command == '/ib_c') {
-      return cancel(args, channelid, userid);
-    } else if (command == '/ib_d') {
-      return done(args, channelid, userid);
-    // Default
-    } else {
-      return ContentService.createTextOutput('error: Sorry, the `' + command + '` command is not currently supported.');
+      return handleSlackCommands(par);
     }
+        
+  }
 }
 
 
@@ -129,8 +84,8 @@ function triggerOnEdit(e){ // this is an installed trigger. see https://develope
   var oldValue = e.oldValue;
   var newValue = e.value;
   
-  var row = e.range.getRow();
-  var col = e.range.getColumn();
+  var rowindex = e.range.getRow();
+  var colindex = e.range.getColumn();
   
   var spreadsheet = e.source;
   var sheet = spreadsheet.getActiveSheet();
@@ -143,20 +98,20 @@ function triggerOnEdit(e){ // this is an installed trigger. see https://develope
   // handle edits on tracking sheet
   if (sheetName==tracking_sheetname){ 
     
-    if (col==colindex_channel+1 && newValue!=undefined){ //handle channel edit (newValue!=undefined avoids capturing undo - i.e. Ctrl+Z - and blank cell events)  
+    if (colindex==colindex_channel+1 && newValue!=undefined){ //handle channel edit (newValue!=undefined avoids capturing undo - i.e. Ctrl+Z - and blank cell events)  
       
       // post message to slack and update sheets
       var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-      postRequest(sheet, row, tracking_sheet_col_index, webhook_chatPostMessage, access_token, 'dispatchUpdate', sheet_log);
+      postRequest(sheet, rowindex, tracking_sheet_col_index, webhook_chatPostMessage, access_token, 'dispatchUpdate', sheet_log);
       
-    } else if (col==colindex_status+1){ // handle status edit
+    } else if (colindex==colindex_status+1){ // handle status edit
       
       if(newValue=='Re-open'){ // if "re-open", trigger the cancel function
-        cancel_su(row);
+        cancel_su(rowindex);
         
       } else{ // for other status changes, just log the change
         // get uniqueid
-        var uniqueid = getUniqueIDbyRow(row, globvar['UNIQUEID_START_VAL'], globvar['UNIQUEID_START_ROWINDEX']);
+        var uniqueid = getUniqueIDbyRowNumber(rowindex, globvar['UNIQUEID_START_VAL'], globvar['UNIQUEID_START_ROWINDEX']);
         
         // update log sheet
         var sheet_log = spreadsheet.getSheetByName(log_sheetname);

--- a/slack_assign.gs
+++ b/slack_assign.gs
@@ -15,6 +15,8 @@ function assign(args, channelid, userid) {
   var uniqueid = args[0];
   var re = new RegExp("<@(U[A-Z0-9]+)\\|?(.*)>"); // regexp match for user_id and user_name in mention string
   var user_re = re.exec(args[1]); // RegExp.exec returns array. First element is matched string, following elements are matched groupings.
+  
+  // check user_re argument
   if (user_re === null){
     return ContentService.createTextOutput('error: I did not recognise the user you specified. Please specify the user by their mention name. Example: `/assign 1000 <@' + mod_userid  + '>`.');
   }

--- a/slack_cancel.gs
+++ b/slack_cancel.gs
@@ -103,10 +103,10 @@ function cancel(uniqueid, channelid, userid){
                                reply_broadcast: true,
                                channel: channelid})
   };
-  var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options); // Send post request to Slack chat.postMessage API   
+  var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options).getContentText(); // Send post request to Slack chat.postMessage API   
     
   // if post request was unsuccesful, do not update tracking sheet and log error
-  var return_params = JSON.parse(return_message.getContentText());
+  var return_params = JSON.parse(return_message);
   if (return_params.ok !== true){ // message was not successfully posted to channel
     // update log sheet
     var sheet_log = spreadsheet.getSheetByName(log_sheetname);
@@ -132,3 +132,98 @@ function cancel(uniqueid, channelid, userid){
                                          'I\'ve notified the channel in the help request thread.');
   
 }
+
+
+
+function cancel_su(row){
+  ///// COMMAND: /CANCEL_SU: cancel function as super-user (without the validity checks). This is used to cancel a request when its status is changed to "re-open" in the spreadsheet.
+  
+  
+  /// define variables
+  var globvar = globalVariables();
+  var mod_userid = globvar['MOD_USERID'];
+  var mention_requestCoord = globvar['MENTION_REQUESTCOORD'];
+  
+  var log_sheetname = globvar['LOG_SHEETNAME'];
+  var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
+  
+  var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
+  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API authentication token
+  
+  var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
+  var tracking_sheet_ncol = tracking_sheet_col_order.length;
+  var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname  
+  
+  var colindex_uniqueid = tracking_sheet_col_index['uniqueid'];
+  var colindex_channelid = tracking_sheet_col_index['channelid']; 
+  var colindex_phone = tracking_sheet_col_index['requesterContact'];
+  var colindex_status = tracking_sheet_col_index['requestStatus']; 
+  var colindex_volunteerName = tracking_sheet_col_index['slackVolunteerName']; 
+  var colindex_volunteerID = tracking_sheet_col_index['slackVolunteerID']; 
+  var colindex_slackts = tracking_sheet_col_index['slackTS']; 
+  var colindex_slacktsurl = tracking_sheet_col_index['slackURL'];
+  var colindex_channel = tracking_sheet_col_index['channel']; 
+  var colindex_requestername = tracking_sheet_col_index['requesterName'];
+  var colindex_address = tracking_sheet_col_index['requesterAddr'];
+  
+  
+  
+  // load sheet
+  var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  var sheet = spreadsheet.getSheetByName(tracking_sheetname);
+  
+  // find requested row in sheet  
+  var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
+  
+  // store fields as separate variables
+  var uniqueid = rowvalues[colindex_uniqueid];
+  var channelid = rowvalues[colindex_channelid]; 
+  var requesterName = rowvalues[colindex_requestername];
+  var address = rowvalues[colindex_address];
+  var slackurl = rowvalues[colindex_slacktsurl];
+  var status = rowvalues[colindex_status]; 
+  var volunteerID = rowvalues[colindex_volunteerID];
+  var slack_ts = rowvalues[colindex_slackts];
+    
+
+  // reply to slack thread to confirm volunteer sign-up (chat.postMessage method)
+  var out_message = '<!channel> <@' + volunteerID + '> is no longer available. Can anyone else volunteer? Type `/volunteer ' + uniqueid + '`.';
+  var options = {
+      method: "post",
+      contentType: 'application/json; charset=utf-8',
+      headers: {Authorization: 'Bearer ' + access_token},
+      payload: JSON.stringify({text: out_message,
+                               thread_ts: slack_ts,
+                               reply_broadcast: true,
+                               channel: channelid})
+  };
+  var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options).getContentText(); // Send post request to Slack chat.postMessage API   
+    
+  // if post request was unsuccesful, do not update tracking sheet and log error
+  var return_params = JSON.parse(return_message);
+  if (return_params.ok !== true){ // message was not successfully posted to channel
+    // update log sheet
+    var sheet_log = spreadsheet.getSheetByName(log_sheetname);
+    var row_log = sheet_log.getLastRow();
+    sheet_log.getRange(row_log+1,1,1,5).setValues([[new Date(), uniqueid,'admin','confirmCancel',return_message]]);
+    
+    // return error to user
+    return ContentService.createTextOutput('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to remove you manually?');
+  }
+  
+  // remove username from sheet and reset status
+  sheet.getRange(row, colindex_volunteerID+1).setValue('');  
+  sheet.getRange(row, colindex_volunteerName+1).setValue('');
+  sheet.getRange(row, colindex_status+1).setValue('Sent');
+  
+  // update log sheet
+  var sheet_log = spreadsheet.getSheetByName(log_sheetname);
+  var row_log = sheet_log.getLastRow();
+  sheet_log.getRange(row_log+1,1,2,5).setValues([[new Date(), uniqueid,'admin','slackCommand','cancel'],
+                                                [new Date(), uniqueid,'admin','confirmCancel',return_message]]);
+  
+  return ContentService.createTextOutput('You just cancelled your offer for help for <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '). '+
+                                         'I\'ve notified the channel in the help request thread.');
+  
+}
+

--- a/slack_cancel.gs
+++ b/slack_cancel.gs
@@ -2,106 +2,43 @@ function cancel(uniqueid, channelid, userid){
   ///// COMMAND: /CANCEL
   
   
-  /// define variables
+  /// declare variables
   var globvar = globalVariables();
-  var mod_userid = globvar['MOD_USERID'];
+  
   var mention_requestCoord = globvar['MENTION_REQUESTCOORD'];
   
-  var log_sheetname = globvar['LOG_SHEETNAME'];
-  var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
-  
+  var tracking_sheet = new TrackingSheetWrapper();
+  var log_sheet = new LogSheetWrapper();
+    
   var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
-  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API authentication token
+  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
   
-  var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
-  var tracking_sheet_ncol = tracking_sheet_col_order.length;
-  var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname  
-  
-  var UNIQUEID_START_VAL = globvar['UNIQUEID_START_VAL'];
-  var UNIQUEID_START_ROWINDEX = globvar['UNIQUEID_START_ROWINDEX'];
-  
-  var colindex_uniqueid = tracking_sheet_col_index['uniqueid'];
-  var colindex_channelid = tracking_sheet_col_index['channelid']; 
-  var colindex_phone = tracking_sheet_col_index['requesterContact'];
-  var colindex_status = tracking_sheet_col_index['requestStatus']; 
-  var colindex_volunteerName = tracking_sheet_col_index['slackVolunteerName']; 
-  var colindex_volunteerID = tracking_sheet_col_index['slackVolunteerID']; 
-  var colindex_slackts = tracking_sheet_col_index['slackTS']; 
-  var colindex_slacktsurl = tracking_sheet_col_index['slackURL'];
-  var colindex_channel = tracking_sheet_col_index['channel']; 
-  var colindex_requestername = tracking_sheet_col_index['requesterName'];
-  var colindex_address = tracking_sheet_col_index['requesterAddr'];
-  
-  
-  // check that request uniqueid has been specified
-  if (uniqueid == ''){
-    return ContentService.createTextOutput('error: You must provide the request number present in the help request message (example: `/cancel 9999`). '+
-                                           'You appear to have not typed any number. If the issue persists, contact ' + mention_requestCoord + '.');
+  // check syntax of command arguments
+  var syntaxCheck_output = checkUniqueID(uniqueid)
+  if (!syntaxCheck_output.code){ // if syntax check returned an error, halt
+    return contentServerJsonReply(syntaxCheck_output.msg);
   }
   
+  // find requested row in sheet
+  var row = tracking_sheet.getRowByUniqueID(uniqueid);
   
-  // check that uniqueid does indeed match a 4-digit string
-  if (!checkUniqueID(uniqueid)){
-    return ContentService.createTextOutput('error: The request number `'+uniqueid+'` does not appear to be a 4-digit number as expected. '+
-                                           'Please specify a correct request number. Example: `/volunteer 1000`.');
-  }
-  
-  
-  // load sheet
-  var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-  var sheet = spreadsheet.getSheetByName(tracking_sheetname);
-  
-  // find requested row in sheet  
-  var row = getRowNumberByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
-  var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
-  if (rowvalues[colindex_uniqueid] != uniqueid){
-    if (rowvalues[colindex_uniqueid] == ''){ // uniqueid points to empty row --> suggests wrong number was entered
-      return ContentService.createTextOutput('error: I couldn\'t find the request number `' + uniqueid + '`. Did you type the right number? '+
-                                             'Type `/listmine` to list the requests you are currently volunteering for in this channel. If the issue persists, contact ' + mention_requestCoord + '.');
-  } else { // uniqueid points to non-empty row but mismatch --> this is a spreadsheet issue. suggests rows are not sorted by uniqueid.
-    return ContentService.createTextOutput('error: Request number lookup failed on server end. Please notify ' + mention_requestCoord);
-    }
-  }
-  
-  // store fields as separate variables
-  var channelid_true = rowvalues[colindex_channelid]; 
-  var requesterName = rowvalues[colindex_requestername];
-  var address = rowvalues[colindex_address];
-  var slackurl = rowvalues[colindex_slacktsurl];
-  var status = rowvalues[colindex_status]; 
-  var volunteerID = rowvalues[colindex_volunteerID];
-  var slack_ts = rowvalues[colindex_slackts];
-  
-  
-  // check that request belongs to the channel from which /cancel message was sent
-  if (channelid != channelid_true) {
-    return ContentService.createTextOutput('error: The request ' + uniqueid + ' does not appear to belong to the channel you are writing from. '+
-                                           'Type `/listmine` to list the requests you are currently volunteering for in this channel.  If the issue persists, contact ' + mention_requestCoord + '.');
-  }
-  
-  // check that request belongs to user and is still ongoing (or that user is moderator)
-  if (volunteerID == '') {
-    return ContentService.createTextOutput('error: You cannot cancel <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') because it is yet to be assigned. '+
-                                           'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
-  } else if (volunteerID != '' && volunteerID != userid && userid!=mod_userid) {
-    return ContentService.createTextOutput('error: You cannot cancel <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') because it is taken by someone else (<@' + volunteerID + '>). '+
-                                           'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
-  } else if (volunteerID == userid && (status != "Assigned" && status != "Ongoing" && status != "ToClose?")){ // mods can bypass this (ie. they can cancel a closed request)
-    return ContentService.createTextOutput('You were signed up on <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '), but it\'s now closed. We therefore won\'t remove you. '+
-                                           'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
+  // check command validity
+  var cmd_check = checkCommandValidity('cancel',row,uniqueid,userid,channelid);
+  if (!cmd_check.code){ // if command check returns error status, halt function and return error message to user
+    return contentServerJsonReply(cmd_check.msg);
   }
     
 
   // reply to slack thread to confirm volunteer sign-up (chat.postMessage method)
-  var out_message = '<!channel> <@' + volunteerID + '> is no longer available. Can anyone else volunteer? Type `/volunteer ' + uniqueid + '`.';
+  var out_message = '<!channel> <@' + row.slackVolunteerID + '> is no longer available. Can anyone else volunteer? Type `/volunteer ' + uniqueid + '`.';
   var options = {
       method: "post",
       contentType: 'application/json; charset=utf-8',
       headers: {Authorization: 'Bearer ' + access_token},
       payload: JSON.stringify({text: out_message,
-                               thread_ts: slack_ts,
+                               thread_ts: row.slackTS,
                                reply_broadcast: true,
-                               channel: channelid})
+                               channel: row.channelid})
   };
   var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options).getContentText(); // Send post request to Slack chat.postMessage API   
     
@@ -109,33 +46,30 @@ function cancel(uniqueid, channelid, userid){
   var return_params = JSON.parse(return_message);
   if (return_params.ok !== true){ // message was not successfully posted to channel
     // update log sheet
-    var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-    var row_log = sheet_log.getLastRow();
-    sheet_log.getRange(row_log+1,1,1,5).setValues([[new Date(), uniqueid,'admin','confirmCancel',return_message]]);
+    log_sheet.appendRow([new Date(), row.uniqueid, 'admin','confirmCancel', return_message]); 
     
     // return error to user
     return ContentService.createTextOutput('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to remove you manually?');
   }
   
-  // remove username from sheet and reset status
-  sheet.getRange(row, colindex_volunteerID+1).setValue('');  
-  sheet.getRange(row, colindex_volunteerName+1).setValue('');
-  sheet.getRange(row, colindex_status+1).setValue('Sent');
+  // write userid, username and status to sheet
+  row.slackVolunteerID = '';
+  row.slackVolunteerName = '';
+  row.requestStatus = "Sent";
+  tracking_sheet.writeRow(row);
   
   // update log sheet
-  var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-  var row_log = sheet_log.getLastRow();
-  sheet_log.getRange(row_log+1,1,2,5).setValues([[new Date(), uniqueid,userid,'slackCommand','cancel'],
-                                                [new Date(), uniqueid,'admin','confirmCancel',return_message]]);
+  log_sheet.appendRow([new Date(), row.uniqueid,'admin','slackCommand','cancel']);
+  log_sheet.appendRow([new Date(), row.uniqueid, 'admin','confirmCancel', return_message]); 
   
-  return ContentService.createTextOutput('You just cancelled your offer for help for <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '). '+
-                                         'I\'ve notified the channel in the help request thread.');
+  // reply privately to user
+  return contentServerJsonReply(cmd_check.msg);
   
 }
 
 
 
-function cancel_su(row){
+function cancel_su(rowindex){
   ///// COMMAND: /CANCEL_SU: cancel function as super-user (without the validity checks). This is used to cancel a request when its status is changed to "re-open" in the spreadsheet.
   
   
@@ -144,85 +78,52 @@ function cancel_su(row){
   var mod_userid = globvar['MOD_USERID'];
   var mention_requestCoord = globvar['MENTION_REQUESTCOORD'];
   
-  var log_sheetname = globvar['LOG_SHEETNAME'];
-  var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
-  
   var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
   var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API authentication token
   
-  var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
-  var tracking_sheet_ncol = tracking_sheet_col_order.length;
-  var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname  
+  var tracking_sheet = new TrackingSheetWrapper();
+  var log_sheet = new LogSheetWrapper();
   
-  var colindex_uniqueid = tracking_sheet_col_index['uniqueid'];
-  var colindex_channelid = tracking_sheet_col_index['channelid']; 
-  var colindex_phone = tracking_sheet_col_index['requesterContact'];
-  var colindex_status = tracking_sheet_col_index['requestStatus']; 
-  var colindex_volunteerName = tracking_sheet_col_index['slackVolunteerName']; 
-  var colindex_volunteerID = tracking_sheet_col_index['slackVolunteerID']; 
-  var colindex_slackts = tracking_sheet_col_index['slackTS']; 
-  var colindex_slacktsurl = tracking_sheet_col_index['slackURL'];
-  var colindex_channel = tracking_sheet_col_index['channel']; 
-  var colindex_requestername = tracking_sheet_col_index['requesterName'];
-  var colindex_address = tracking_sheet_col_index['requesterAddr'];
-  
-  
-  
-  // load sheet
-  var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-  var sheet = spreadsheet.getSheetByName(tracking_sheetname);
   
   // find requested row in sheet  
-  var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
+  var row = tracking_sheet.getRowByRowNumber(rowindex);
   
-  // store fields as separate variables
-  var uniqueid = rowvalues[colindex_uniqueid];
-  var channelid = rowvalues[colindex_channelid]; 
-  var requesterName = rowvalues[colindex_requestername];
-  var address = rowvalues[colindex_address];
-  var slackurl = rowvalues[colindex_slacktsurl];
-  var status = rowvalues[colindex_status]; 
-  var volunteerID = rowvalues[colindex_volunteerID];
-  var slack_ts = rowvalues[colindex_slackts];
-    
 
-  // reply to slack thread to confirm volunteer sign-up (chat.postMessage method)
-  var out_message = '<!channel> <@' + volunteerID + '> is no longer available. Can anyone else volunteer? Type `/volunteer ' + uniqueid + '`.';
+  // reply to slack thread to confirm cancel (chat.postMessage method)
+  var out_message = '<!channel> <@' + row.slackVolunteerID + '> is no longer available. Can anyone else volunteer? Type `/volunteer ' + row.uniqueid + '`.';
   var options = {
       method: "post",
       contentType: 'application/json; charset=utf-8',
       headers: {Authorization: 'Bearer ' + access_token},
       payload: JSON.stringify({text: out_message,
-                               thread_ts: slack_ts,
+                               thread_ts: row.slackTS,
                                reply_broadcast: true,
-                               channel: channelid})
+                               channel: row.channelid})
   };
   var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options).getContentText(); // Send post request to Slack chat.postMessage API   
     
   // if post request was unsuccesful, do not update tracking sheet and log error
   var return_params = JSON.parse(return_message);
   if (return_params.ok !== true){ // message was not successfully posted to channel
-    // update log sheet
-    var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-    var row_log = sheet_log.getLastRow();
-    sheet_log.getRange(row_log+1,1,1,5).setValues([[new Date(), uniqueid,'admin','confirmCancel',return_message]]);
     
+    // update log sheet
+    log_sheet.appendRow([new Date(), row.uniqueid,'admin','confirmCancel',return_message]);
+        
     // return error to user
     return ContentService.createTextOutput('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to remove you manually?');
   }
   
-  // remove username from sheet and reset status
-  sheet.getRange(row, colindex_volunteerID+1).setValue('');  
-  sheet.getRange(row, colindex_volunteerName+1).setValue('');
-  sheet.getRange(row, colindex_status+1).setValue('Sent');
+  // write userid, username and status to sheet
+  row.slackVolunteerID = '';
+  row.slackVolunteerName = '';
+  row.requestStatus = "Sent";
+  tracking_sheet.writeRow(row);
   
   // update log sheet
-  var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-  var row_log = sheet_log.getLastRow();
-  sheet_log.getRange(row_log+1,1,2,5).setValues([[new Date(), uniqueid,'admin','slackCommand','cancel'],
-                                                [new Date(), uniqueid,'admin','confirmCancel',return_message]]);
+  log_sheet.appendRow([new Date(), row.uniqueid,'admin','slackCommand','cancel']);
+  log_sheet.appendRow([new Date(), row.uniqueid, 'admin','confirmCancel', return_message]);   
   
-  return ContentService.createTextOutput('You just cancelled your offer for help for <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '). '+
+  return ContentService.createTextOutput('You just cancelled your offer for help for <' + row.slackURL + '|request ' + row.uniqueid + '> (' + row.requesterName + ', ' + row.requesterAddr + '). '+
                                          'I\'ve notified the channel in the help request thread.');
   
 }

--- a/slack_cancel.gs
+++ b/slack_cancel.gs
@@ -86,7 +86,7 @@ function cancel(uniqueid, channelid, userid){
   } else if (volunteerID != '' && volunteerID != userid && userid!=mod_userid) {
     return ContentService.createTextOutput('error: You cannot cancel <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') because it is taken by someone else (<@' + volunteerID + '>). '+
                                            'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
-  } else if (volunteerID == userid && (status != "Assigned" && status != "Ongoing")){ // mods can bypass this (ie. they can cancel a closed request)
+  } else if (volunteerID == userid && (status != "Assigned" && status != "Ongoing" && status != "ToClose?")){ // mods can bypass this (ie. they can cancel a closed request)
     return ContentService.createTextOutput('You were signed up on <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '), but it\'s now closed. We therefore won\'t remove you. '+
                                            'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
   }

--- a/slack_done.gs
+++ b/slack_done.gs
@@ -1,5 +1,153 @@
-function done(uniqueid, channelid, userid){
-  ///// COMMAND: /CANCEL
+function done_send_modal(uniqueid, channelid, userid, response_url, slack_trigger_id){
+/// done_send_modal: Open up a slack modal so that user can provide more information about his /done instance
+  
+  
+  /// define variables
+  var globvar = globalVariables();
+  var mention_requestCoord = globvar['MENTION_REQUESTCOORD'];
+  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API authentication token
+  
+  
+  // check that request uniqueid has been specified
+  if (uniqueid == ''){
+    return ('error: You must provide the request number present in the help request message (example: `/done 9999`). '+
+                                           'You appear to have not typed any number. If the issue persists, contact ' + mention_requestCoord + '.');
+  }
+  
+  // check that uniqueid does indeed match a 4-digit string
+  if (!checkUniqueID(uniqueid)){
+    return ('error: The request number `'+uniqueid+'` does not appear to be a 4-digit number as expected. '+
+                                           'Please specify a correct request number. Example: `/done 1000`.');
+  }
+  
+  // Send post request to Slack views.open API to open a modal for user  
+  var cmd_metadata = JSON.stringify({
+    uniqueid: uniqueid,
+    channelid: channelid,
+    response_url: response_url
+  }); // data passed as metadata in modal, to follow up on command request once modal user submission is received 
+  var out_modal = {
+	"type": "modal",
+	"title": {"type": "plain_text","text": "How did it go?"},
+    "callback_id": "done_clarify",
+    "private_metadata": cmd_metadata,
+	"submit": {"type": "plain_text","text": "Submit"},
+	"close": {"type": "plain_text","text": "Cancel"},
+	"blocks": [
+		{
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": ":wave: Hi <@"+userid+">,\n\nThanks for letting me know you have provided help for request number "+uniqueid+". The on-duty request coordinator has some questions, would you mind taking a few seconds to fill them in?"
+          }
+		},
+		{
+          "type": "divider"
+		},
+		{
+          "type": "input",
+          "block_id": "requestNextStatus",
+          "label": {"type": "plain_text","text": "Should this request be closed?"},
+          "element": {
+            "type": "radio_buttons",
+            "action_id":"requestNextStatusVal",
+            "options": [
+              {
+                "text": {"type": "plain_text","text": "Yes"},
+                "value": "toClose"
+              },
+              {
+                "text": {"type": "plain_text","text": "No, keep me assigned"},
+                "value": "keepOpenAssigned"
+              },
+              {
+                "text": {"type": "plain_text","text": "No, assign a new volunteer"},
+                "value": "keepOpenNew"
+              },
+              {
+                "text": {"type": "plain_text","text": "I don't know"},
+                "value": "unsure"
+              }
+            ]
+          }
+		},
+		{
+          "type": "input",
+          "block_id": "completionLastDetails",
+          "label": {"type": "plain_text","text": "Anything else you'd like to add?"},
+          "element": {"type": "plain_text_input","action_id":"completionLastDetailsVal","multiline": true},
+          "optional": true
+		}]
+  };
+  var options = {
+    method: "post",
+    contentType: 'application/json; charset=utf-8',
+    headers: {Authorization: 'Bearer ' + access_token},
+    payload: JSON.stringify({trigger_id: slack_trigger_id,
+                             view: JSON.stringify(out_modal)})
+  }; 
+  var return_message = UrlFetchApp.fetch('https://slack.com/api/views.open', options).getContentText();
+  
+  
+  // check that modal sent properly 
+  var return_params = JSON.parse(return_message);
+  var return_ok = return_params.ok;
+  if (return_ok !== true){
+    return ('I failed to open the /done submission form. Can you please notify a developer? This is the error message:\n'+return_message);
+  }
+
+  return ('A request completion form will open in less than 3 seconds... if not, please type `/done '+uniqueid+'` again.');
+}
+
+
+function done_process_modal(userid,view){
+  /// done_process_modal: Read done modal submission. Process done command.
+  
+  /// declare variables
+  var globvar = globalVariables();
+  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
+  var log_sheetname = globvar['LOG_SHEETNAME'];
+  
+  // get uniqueid/channelid/response_url from modal private_metadata 
+  var cached_values = JSON.parse(view.private_metadata);
+  var uniqueid = cached_values.uniqueid;
+  var channelid = cached_values.channelid;
+  var response_url = cached_values.response_url;
+  
+  // get response values in modal
+  var modalResponseVals = view.state.values;
+  var requestNextStatus = modalResponseVals.requestNextStatus.requestNextStatusVal.selected_option.value;
+  var completionLastDetails = modalResponseVals.completionLastDetails.completionLastDetailsVal.value;
+  if (!completionLastDetails){
+    completionLastDetails=''; // replace undefined with ''
+  }
+  
+  // process done command
+  var out_message = done(uniqueid, channelid, userid, requestNextStatus, completionLastDetails);
+  
+  // send reply to slack user with response_url functionality
+  var options = {
+    method: "post",
+    contentType: 'application/json; charset=utf-8',
+    headers: {Authorization: 'Bearer ' + access_token},
+    payload: JSON.stringify({
+      "text": out_message,
+      "response_type": "ephemeral"
+    })
+  };
+  var return_message = UrlFetchApp.fetch(response_url, options).getContentText(); // Send post request to Slack response_url  
+  
+  // update log sheet
+  var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  var sheet_log = spreadsheet.getSheetByName(log_sheetname);
+  var row_log = sheet_log.getLastRow();
+  sheet_log.getRange(row_log+1,1,1,5).setValues([[new Date(), uniqueid,'admin','confirmDoneUser',return_message]]);
+}
+
+
+
+function done(uniqueid, channelid, userid, requestNextStatus, completionLastDetails){
+  ///// COMMAND: /DONE
     
   
   /// define variables
@@ -31,18 +179,21 @@ function done(uniqueid, channelid, userid){
   var colindex_channel = tracking_sheet_col_index['channel']; 
   var colindex_requestername = tracking_sheet_col_index['requesterName'];
   var colindex_address = tracking_sheet_col_index['requesterAddr'];
+  var colindex_completionCount = tracking_sheet_col_index['completionCount'];
+  var colindex_completionLastTimestamp = tracking_sheet_col_index['completionLastTimestamp']; 
+  var colindex_completionLastDetails = tracking_sheet_col_index['completionLastDetails'];  
   
   
   // check that request uniqueid has been specified
   if (uniqueid == ''){
-    return ContentService.createTextOutput('error: You must provide the request number present in the help request message (example: `/done 9999`). '+
+    return ('error: You must provide the request number present in the help request message (example: `/done 9999`). '+
                                            'You appear to have not typed any number. If the issue persists, contact ' + mention_requestCoord + '.');
   }
   
   // check that uniqueid does indeed match a 4-digit string
   if (!checkUniqueID(uniqueid)){
-    return ContentService.createTextOutput('error: The request number `'+uniqueid+'` does not appear to be a 4-digit number as expected. '+
-                                           'Please specify a correct request number. Example: `/volunteer 1000`.');
+    return ('error: The request number `'+uniqueid+'` does not appear to be a 4-digit number as expected. '+
+                                           'Please specify a correct request number. Example: `/done 1000`.');
   }
   
   
@@ -55,10 +206,10 @@ function done(uniqueid, channelid, userid){
   var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
   if (rowvalues[colindex_uniqueid] != uniqueid){
     if (rowvalues[colindex_uniqueid] == ''){ // uniqueid points to empty row --> suggests wrong number was entered
-      return ContentService.createTextOutput('error: I couldn\'t find the request number `' + uniqueid + '`. Did you type the right number? '+
+      return ('error: I couldn\'t find the request number `' + uniqueid + '`. Did you type the right number? '+
                                              'Type `/listmine` to list the requests you are currently volunteering for in this channel. If the issue persists, contact ' + mention_requestCoord + '.');
   } else { // uniqueid points to non-empty row but mismatch --> this is a spreadsheet issue. suggests rows are not sorted by uniqueid.
-    return ContentService.createTextOutput(row +' '+ rowvalues[colindex_uniqueid-1] + ' error: Request number lookup failed on server end. Please notify ' + mention_requestCoord);
+    return (row +' '+ rowvalues[colindex_uniqueid-1] + ' error: Request number lookup failed on server end. Please notify ' + mention_requestCoord);
     }
   }
   
@@ -70,29 +221,27 @@ function done(uniqueid, channelid, userid){
   var status = rowvalues[colindex_status]; 
   var volunteerID = rowvalues[colindex_volunteerID];
   var slack_ts = rowvalues[colindex_slackts];
+  var completionCount = rowvalues[colindex_completionCount];
   
   
   // check that request belongs to the channel from which /done message was sent
   if (channelid != channelid_true) {
-    return ContentService.createTextOutput('error: The request ' + uniqueid + ' does not appear to belong to the channel you are writing from. '+
+    return ('error: The request ' + uniqueid + ' does not appear to belong to the channel you are writing from. '+
                                            'Type `/listmine` to list the requests you are currently volunteering for in this channel.  If the issue persists, contact ' + mention_requestCoord + '.');
   }
   
-  // check that request belongs to user and is still ongoing
+  // check that request belongs to user
   if (volunteerID == '') {
-    return ContentService.createTextOutput('error: You cannot complete <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') because it is yet to be assigned. '+
+    return ('error: You cannot complete <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') because it is yet to be assigned. '+
                                            'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
   } else if (volunteerID != '' && volunteerID != userid && userid!=mod_userid) {
-    return ContentService.createTextOutput('error: You cannot complete <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') because it is taken by someone else (<@' + volunteerID + '>). '+
-                                           'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
-  } else if ((volunteerID == userid || userid==mod_userid) && (status != "Assigned" && status != "Ongoing")){
-    return ContentService.createTextOutput('<' + slackurl + '|Request ' + uniqueid + '> (' + requesterName + ', ' + address + '), is already marked as closed. '+
+    return ('error: You cannot complete <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') because it is taken by someone else (<@' + volunteerID + '>). '+
                                            'Type `/listmine` to list the requests you are currently volunteering for in this channel. If you think there is a mistake, contact ' + mention_requestCoord + '.');
   }
     
     
-  // reply to slack thread to confirm volunteer sign-up (chat.postMessage method)
-  var out_message = 'The help request is now closed. Thanks <@' + volunteerID + '>! :nerd_face:';
+  // reply to slack thread to confirm done instance (chat.postMessage method)
+  var out_message = 'Thanks for helping out <@' + volunteerID + '>! :nerd_face:';
   var options = {
     method: "post",
     contentType: 'application/json; charset=utf-8',
@@ -102,10 +251,10 @@ function done(uniqueid, channelid, userid){
                              channel: channelid})
   };
   // Send post request to Slack chat.postMessage API   
-  var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options);
+  var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options).getContentText();
   
   // if post request was unsuccesful, do not update tracking sheet and return error
-  var return_params = JSON.parse(return_message.getContentText());
+  var return_params = JSON.parse(return_message);
   if (return_params.ok !== true){ // message was not successfully posted to channel
     // update log sheet
     var sheet_log = spreadsheet.getSheetByName(log_sheetname);
@@ -113,19 +262,29 @@ function done(uniqueid, channelid, userid){
     sheet_log.getRange(row_log+1,1,1,5).setValues([[new Date(), uniqueid,'admin','confirmDone',return_message]]);
     
     // return error to user
-    return ContentService.createTextOutput('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to close the request manually?');
+    return ('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to close the request manually?');
   }
-  
-  // set status to "Closed"
-  sheet.getRange(row, colindex_status+1).setValue('Closed');
   
   // update log sheet
   var sheet_log = spreadsheet.getSheetByName(log_sheetname);
   var row_log = sheet_log.getLastRow();
   sheet_log.getRange(row_log+1,1,2,5).setValues([[new Date(), uniqueid,userid,'slackCommand','done'],
-                                                [new Date(), uniqueid,'admin','confirmDone',return_message]]);
+                                                [new Date(), uniqueid,'admin','confirmDone',return_message]]);  
   
-  return ContentService.createTextOutput('You have confirmed completing <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '). '+
-                                         'I\'ve notified the channel in the help request thread. If you wish to make this help request active again, contact ' + mention_requestCoord + '.');
+  // update tracking sheet
+  if ((requestNextStatus === '') || (requestNextStatus === 'unsure') || (requestNextStatus === 'toClose')){
+    sheet.getRange(row, colindex_status+1).setValue('ToClose?');
+  } else if (requestNextStatus === 'keepOpenNew'){
+    cancel(uniqueid, channelid, userid);
+  } else if (requestNextStatus === 'keepOpenAssigned'){
+    sheet.getRange(row, colindex_status+1).setValue('Assigned');
+  }
+  sheet.getRange(row, colindex_completionCount+1).setValue(+completionCount+1); // increment completionCount
+  sheet.getRange(row, colindex_completionLastDetails+1).setValue(completionLastDetails); // update completionLastDetails
+  sheet.getRange(row, colindex_completionLastTimestamp+1).setValue(new Date()); // update completionLastTimestamp to current time
+  
+  
+  return ('You have confirmed completing <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '). '+
+                                         'I\'ve notified volunteers in the help request thread and sent your form submission to the request coordinator on-duty.');
   
 }

--- a/slack_messages.gs
+++ b/slack_messages.gs
@@ -10,11 +10,19 @@ function contentServerJsonReply(message) {
 }
 
 
-function volunteerSuccessReply(slackurl, uniqueid, requesterName, mention_requestCoord, address, contactDetails, householdSituation) {
+function volunteerSuccessReply(slackurl, uniqueid, requesterName, mention_requestCoord, address, contactDetails, householdSituation,isFirstMessage) {
   var householdMessage = "";
   if (householdSituation != ""){
-    householdMessage = "\nTheir household situation is " + householdSituation + ".\n"
+    householdMessage = "\nTheir household situation is: " + householdSituation + ".\n"
   }
+  
+  // personalise text depending on whether this is the first time volunteer sees the message or not
+  if (isFirstMessage){
+    var introTxt = ":nerd_face::tada: You signed up for <" + slackurl + "|request " + uniqueid + ">."
+  } else{
+    var introTxt = ":nerd_face::tada: You are still signed up for <" + slackurl + "|request " + uniqueid + ">."
+  }
+  
   // Json Template for replying to successful volunteer messages.
   return JSON.stringify({
 	"blocks": [
@@ -22,7 +30,7 @@ function volunteerSuccessReply(slackurl, uniqueid, requesterName, mention_reques
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "You signed up for <" + slackurl + "|request " + uniqueid + "> "
+				"text": introTxt
 			}
 		},
 		{
@@ -39,7 +47,7 @@ function volunteerSuccessReply(slackurl, uniqueid, requesterName, mention_reques
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": ":tada:. \nWhen you are done, type `/done " + uniqueid + "`"
+				"text": "When you are done, type `/done " + uniqueid + "`"
 			}
 		},
 		{
@@ -60,7 +68,7 @@ function volunteerSuccessReply(slackurl, uniqueid, requesterName, mention_reques
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "If you need any help, contact " + mention_requestCoord + "."
+				"text": "If you need any help, please contact " + mention_requestCoord + "."
 			}
 		}
 	]      

--- a/slack_volunteer.gs
+++ b/slack_volunteer.gs
@@ -110,10 +110,10 @@ function volunteer (uniqueid, channelid, userid, username){
                                channel: channelid})
     };
   // Send post request to Slack chat.postMessage API   
-  var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options);
+  var return_message = UrlFetchApp.fetch(webhook_chatPostMessage, options).getContentText();
   
   // if post request was unsuccesful, do not update tracking sheet and return error
-  var return_params = JSON.parse(return_message.getContentText());
+  var return_params = JSON.parse(return_message);
   if (return_params.ok !== true){ // message was not successfully posted to channel
     
     // update log sheet

--- a/variables.gs
+++ b/variables.gs
@@ -13,40 +13,47 @@ function globalVariables(){
     SHEET_ROW_OFFSET: 0, // *relative* row offset of trigger sheet compared to form response sheet: rowIndex_triggerSheet = rowIndex_responseSheet + SHEET_ROW_OFFSET. This is used to find the right row in trigger sheet when a new form submission occurs.
     UNIQUEID_START_VAL: 1000, // value of first uniqueid
     UNIQUEID_START_ROWINDEX: 2, // row index of first uniqueid in tracking sheet. Used for quick row lookup based on uniqueid value.
-    SHEET_COL_ORDER: ["uniqueid",
-                      "timestamp",
-                      "requesterName",
-                      "requesterContact",
-                      "requesterAddr",
-                      "householdSit",
-                      "requestType",
-                      "requestDate",
-                      "requestInfo",
-                      "channel",
-                      "requesterGeneralNeeds",
-                      "coordinatorName",
-                      "commentsForSlack",
-                      "requestStatus",
-                      "slackURL",
-                      "slackTS",
-                      "commentsForCoordinator",
-                      "slackVolunteerName",
-                      "channelid",
-                      "slackVolunteerID",
-                     "completionCount",
-                     "completionLastTimestamp",
-                     "completionLastDetails",
-                     "nextDateNeeded"], // tracking sheet column order. ie: first element is col 'A', second is col 'B', ... 
-//    The strings need not match the actual sheet's header strings. They must match the strings called in the script functions.
+    
+    // Tracking sheet column order. ie: first element is col 'A', second is col 'B', ... 
+    // The strings need not match the actual sheet's header strings. They must match the strings called in the script functions.
+    SHEET_COL_ORDER: [
+      "uniqueid",
+      "timestamp",
+      "requesterName",
+      "requesterContact",
+      "requesterAddr",
+      "householdSit",
+      "requestType",
+      "requestDate",
+      "requestInfo",
+      "channel",
+      "requesterGeneralNeeds",
+      "coordinatorName",
+      "commentsForSlack",
+      "requestStatus",
+      "slackURL",
+      "slackTS",
+      "commentsForCoordinator",
+      "slackVolunteerName",
+      "channelid",
+      "slackVolunteerID",
+      "completionCount",
+      "completionLastTimestamp",
+      "completionLastDetails",
+      "nextDateNeeded"],
+    
     // A list of columns that can be updated via this script.
     // This is to prevent accidental overwritting of sheet columns.
     MACHINE_WRITABLE_COLS: [
-                      "commentsForSlack",
-                      "requestStatus",
-                      "slackTS",
-                      "slackVolunteerName",
-                      "channelid",
-                      "slackVolunteerID"],
+      "requestStatus",
+      "slackTS",
+      "slackVolunteerName",
+      "channelid",
+      "slackVolunteerID",
+      "completionCount",
+      "completionLastTimestamp",
+      "completionLastDetails"],
+    
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage'
   };
   return globvar;

--- a/variables.gs
+++ b/variables.gs
@@ -32,7 +32,11 @@ function globalVariables(){
                       "commentsForCoordinator",
                       "slackVolunteerName",
                       "channelid",
-                      "slackVolunteerID"], // tracking sheet column order. ie: first element is col 'A', second is col 'B', ... 
+                      "slackVolunteerID",
+                     "completionCount",
+                     "completionLastTimestamp",
+                     "completionLastDetails",
+                     "nextDateNeeded"], // tracking sheet column order. ie: first element is col 'A', second is col 'B', ... 
 //    The strings need not match the actual sheet's header strings. They must match the strings called in the script functions.
     
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage'


### PR DESCRIPTION
slack /done command now opens a slack form (modal)
modal response is handled in doPost function, and ultimately triggers _done_ function
_done_ function accepts multiple help instances and, based on modal form details, updates status accordingly