### PR TITLE
Add communication of full address and household situation.

### DIFF
--- a/functions.gs
+++ b/functions.gs
@@ -5,6 +5,15 @@ function getRowByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX)
   return(row);
 }
 
+
+function stripStartingNumbers(s){
+  // Strip starting numbers from a string.
+  // Use to remove house numbers when posting publically.
+  var re = new RegExp(/^[\s\d]+/);
+  return s.replace(re, "");
+}
+
+
 //function getRowByColVal(sheetvalues, colindex, value){    
 //    var row;
 //    for (var i = 0; i < sheetvalues.length ; i++)
@@ -59,7 +68,7 @@ function postRequest(sheet, row, tracking_sheet_col_index, webhook_chatPostMessa
   
   var uniqueid = sheet.getRange(row, colindex_uniqueid+1).getValue();
   var requesterName = sheet.getRange(row, colindex_requestername+1).getValue();
-  var address = sheet.getRange(row, colindex_address+1).getValue();
+  var address = stripStartingNumbers(sheet.getRange(row, colindex_address+1).getValue());
   var requestType = sheet.getRange(row, colindex_requestType+1).getValue();
   var requestDateUnformatted = new Date (sheet.getRange(row, colindex_requestDate+1).getValue());
   var requestDate = requestDateUnformatted.getDate() + '/' + (requestDateUnformatted.getMonth() + 1) +'/'+ requestDateUnformatted.getFullYear( ); // DD/MM/YYYY

--- a/functions.gs
+++ b/functions.gs
@@ -1,6 +1,6 @@
 // sheet functions
 
-function getRowByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX){
+function getRowNumberByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX){
   var row = +uniqueid - UNIQUEID_START_VAL +UNIQUEID_START_ROWINDEX; // assumes: tracking sheet rows are sorted by contiguous increasing request-number
   return(row);
 }

--- a/main.gs
+++ b/main.gs
@@ -69,6 +69,14 @@ function doPost(e) { // catches slack slash commands
       return cancel(args, channelid, userid);
     } else if (command == '/jb_d') {
       return done(args, channelid, userid);
+    // IB dev switch
+    } else if (command == '/ib_v'){
+      return volunteer(args, channelid, userid, username);      
+    } else if (command == '/ib_c') {
+      return cancel(args, channelid, userid);
+    } else if (command == '/ib_d') {
+      return done(args, channelid, userid);
+    // Default
     } else {
       return ContentService.createTextOutput('error: Sorry, the `' + command + '` command is not currently supported.');
     }

--- a/sheet_wrapper.gs
+++ b/sheet_wrapper.gs
@@ -1,0 +1,70 @@
+class TrackingSheetWrapper {
+  // Wrapper around the tracking sheet.
+
+  constructor(){
+    var globvar = globalVariables();
+    var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    this.sheet = spreadsheet.getSheetByName(globvar['TRACKING_SHEETNAME']);
+    this.columns = globvar["SHEET_COL_ORDER"];
+    this.machine_writable_columns = globvar["MACHINE_WRITABLE_COLS"];
+    this.numColumns = this.columns.length;
+    this.UNIQUEID_START_VAL = globvar['UNIQUEID_START_VAL'];
+    this.UNIQUEID_START_ROWINDEX = globvar['UNIQUEID_START_ROWINDEX'];
+  }
+  
+  getRowByRowNumber(rowNumber){
+    // Return a row object based on row number.
+    var rowArray = this.sheet.getRange(rowNumber, 1, 1, this.numColumns).getValues();
+    rowArray = rowArray[0];  // Shape [1, R] -> [R]
+    var row = {};
+    for (var i = 0; i < this.columns.length; i++) {
+      row[this.columns[i]] = rowArray[i];
+    }
+    return row;
+  }
+  
+  getRowByUniqueID(id){
+    // Returns a row object based on uniqueid.
+    return this.getRowByRowNumber(
+      getRowByUniqueID(id, this.UNIQUEID_START_VAL, this.UNIQUEID_START_ROWINDEX));
+  }
+  
+  writeRow(row){
+    // Writes a row object to the tracking sheet based on it's unique id.
+    // "row" needs to contain a uniqueid.
+    // all other elements with keys in machine_writable_columns will be written to the sheet.
+    var rowNumber = getRowByUniqueID(row.uniqueid, this.UNIQUEID_START_VAL, this.UNIQUEID_START_ROWINDEX);
+    var existingRow = this.getRowByUniqueID(row.uniqueid);
+    if (existingRow.uniqueid != row.uniqueid){
+      throw "Attempting to write to row with unmatching uniqueids. id: " + row.uniqueid;
+    }
+    
+    for (var i = 0; i < this.columns.length; i++) {
+      if (this.machine_writable_columns.indexOf(this.columns[i]) != -1){
+        var value = row[this.columns[i]];
+        if (value !== null){
+          // We need the +1 in the column here because columns are indexed from 1....
+          this.sheet.getRange(rowNumber, i+1).setValue(value);
+        }
+      }
+    }
+  }
+}
+
+
+class LogSheetWrapper {
+  // Wrapper around the logging sheet.
+
+  constructor(){
+    var globvar = globalVariables();
+    var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    this.sheet = spreadsheet.getSheetByName(globvar['LOG_SHEETNAME']);  
+  }
+  
+  appendRow(row){
+    // Append array row to the end of the sheet.
+    var row_log = this.sheet.getLastRow();
+    this.sheet.getRange(row_log+1,1,1, row.length).setValues([row]);
+  }
+}
+

--- a/sheet_wrapper.gs
+++ b/sheet_wrapper.gs
@@ -26,14 +26,14 @@ class TrackingSheetWrapper {
   getRowByUniqueID(id){
     // Returns a row object based on uniqueid.
     return this.getRowByRowNumber(
-      getRowByUniqueID(id, this.UNIQUEID_START_VAL, this.UNIQUEID_START_ROWINDEX));
+      getRowNumberByUniqueID(id, this.UNIQUEID_START_VAL, this.UNIQUEID_START_ROWINDEX));
   }
   
   writeRow(row){
     // Writes a row object to the tracking sheet based on it's unique id.
     // "row" needs to contain a uniqueid.
     // all other elements with keys in machine_writable_columns will be written to the sheet.
-    var rowNumber = getRowByUniqueID(row.uniqueid, this.UNIQUEID_START_VAL, this.UNIQUEID_START_ROWINDEX);
+    var rowNumber = getRowNumberByUniqueID(row.uniqueid, this.UNIQUEID_START_VAL, this.UNIQUEID_START_ROWINDEX);
     var existingRow = this.getRowByUniqueID(row.uniqueid);
     if (existingRow.uniqueid != row.uniqueid){
       throw "Attempting to write to row with unmatching uniqueids. id: " + row.uniqueid;

--- a/slack_cancel.gs
+++ b/slack_cancel.gs
@@ -52,7 +52,7 @@ function cancel(uniqueid, channelid, userid){
   var sheet = spreadsheet.getSheetByName(tracking_sheetname);
   
   // find requested row in sheet  
-  var row = getRowByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
+  var row = getRowNumberByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
   var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
   if (rowvalues[colindex_uniqueid] != uniqueid){
     if (rowvalues[colindex_uniqueid] == ''){ // uniqueid points to empty row --> suggests wrong number was entered

--- a/slack_done.gs
+++ b/slack_done.gs
@@ -51,7 +51,7 @@ function done(uniqueid, channelid, userid){
   var sheet = spreadsheet.getSheetByName(tracking_sheetname);
   
   // find requested row in sheet  
-  var row = getRowByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
+  var row = getRowNumberByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
   var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
   if (rowvalues[colindex_uniqueid] != uniqueid){
     if (rowvalues[colindex_uniqueid] == ''){ // uniqueid points to empty row --> suggests wrong number was entered

--- a/slack_list.gs
+++ b/slack_list.gs
@@ -73,9 +73,9 @@ function listactive (channelid){
     if ((row[colindex_status] == '' || row[colindex_status] == 'Sent' || row[colindex_status] == 'Assigned' || row[colindex_status] == 'Ongoing') && row[colindex_channelid] == channelid) { // non-closed status and correct channel
       
       if (row[colindex_status] == '' || row[colindex_status] == 'Sent'){ // perform different formatting for unassigned requests (when status field is empty)
-        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   Unassigned   (' + row[colindex_requestername] + '   ' + row[colindex_address] + '   ' + row[colindex_requestType] + ')\n';
+        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   Unassigned   (' + row[colindex_requestername] + '   ' + stripStartingNumbers(row[colindex_address]) + '   ' + row[colindex_requestType] + ')\n';
       } else {
-        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   ' + row[colindex_status] + '   <@' + row[colindex_volunteerID] + '>   (' + row[colindex_requestername] + '   ' + row[colindex_address] + '   ' + row[colindex_requestType] + ')\n';
+        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   ' + row[colindex_status] + '   <@' + row[colindex_volunteerID] + '>   (' + row[colindex_requestername] + '   ' + stripStartingNumbers(row[colindex_address]) + '   ' + row[colindex_requestType] + ')\n';
       }
     }
   });
@@ -118,9 +118,9 @@ function listall (channelid){ // may want to sort the output message by status i
     if (row[colindex_channelid] == channelid) { // correct channel 
       
       if (row[colindex_status] == '' || row[colindex_status] == 'Sent'){ // perform different formatting for unassigned requests (when status field is empty)
-        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   Unassigned   (' + row[colindex_requestername] + '   ' + row[colindex_address] + '   ' + row[colindex_requestType] + ')\n';
+        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   Unassigned   (' + row[colindex_requestername] + '   ' + stripStartingNumbers(row[colindex_address]) + '   ' + row[colindex_requestType] + ')\n';
       } else {
-        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   ' + row[colindex_status] + '   <@' + row[colindex_volunteerID] + '>   (' + row[colindex_requestername] + '   ' + row[colindex_address] + '   ' + row[colindex_requestType] + ')\n';
+        message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   ' + row[colindex_status] + '   <@' + row[colindex_volunteerID] + '>   (' + row[colindex_requestername] + '   ' + stripStartingNumbers(row[colindex_address]) + '   ' + row[colindex_requestType] + ')\n';
       }
     }
   });
@@ -160,7 +160,7 @@ function listmine (channelid, userid){
   // scan through rows and append relevant information to output message
   sheetvalues.forEach(function(row) {
     if ((row[colindex_status] == '' || row[colindex_status] == 'Sent' || row[colindex_status] == 'Assigned' || row[colindex_status] == 'Ongoing') && row[colindex_channelid] == channelid && row[colindex_volunteerID] == userid) { // non-closed status, correct channel and user
-      message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   (' + row[colindex_requestername] + '   ' + row[colindex_address] + '   ' + row[colindex_requestType] + ')\n';
+      message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   (' + row[colindex_requestername] + '   ' + stripStartingNumbers(row[colindex_address]) + '   ' + row[colindex_requestType] + ')\n';
     }
   });
  

--- a/slack_list.gs
+++ b/slack_list.gs
@@ -32,7 +32,7 @@ function list (channelid){
   // scan through rows and append relevant information to output message  
   sheetvalues.forEach(function(row) { // append...
     if ((row[colindex_status] == '' || row[colindex_status] == 'Sent') && row[colindex_channelid] == channelid) { // ... if empty status and correct channel
-      message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   (' + row[colindex_requestername] + '   ' + row[colindex_address] + '   ' + row[colindex_requestType] + ')\n';
+      message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   (' + row[colindex_requestername] + '   ' + stripStartingNumbers(row[colindex_address]) + '   ' + row[colindex_requestType] + ')\n';
     }
   });
  
@@ -199,7 +199,7 @@ function listallmine (channelid, userid){
   // scan through rows and append relevant information to output message
   sheetvalues.forEach(function(row) {
     if (row[colindex_channelid] == channelid && row[colindex_volunteerID] == userid) { // correct channel and user
-      message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   ' + row[colindex_status] + '   (' + row[colindex_requestername] + '   ' + row[colindex_address] + '   ' + row[colindex_requestType] + ')\n';
+      message_out += '<' + row[colindex_slacktsurl] + '|Request ' + row[colindex_uniqueid] + '>   ' + row[colindex_status] + '   (' + row[colindex_requestername] + '   ' + stripStartingNumbers(row[colindex_address]) + '   ' + row[colindex_requestType] + ')\n';
     }
   });
  

--- a/slack_messages.gs
+++ b/slack_messages.gs
@@ -1,0 +1,68 @@
+// Some functions for formatting and sending messages to slack.
+// For more slack formating, see:
+// https://api.slack.com/tools/block-kit-builder
+
+function contentServerJsonReply(message) {
+  // "ContentServer" reply as Json.
+  return ContentService
+         .createTextOutput(message)
+         .setMimeType(ContentService.MimeType.JSON);
+}
+
+
+function volunteerSuccessReply(slackurl, uniqueid, requesterName, mention_requestCoord, address, contactDetails, householdSituation) {
+  var householdMessage = "";
+  if (householdSituation != ""){
+    householdMessage = "\nTheir household situation is " + householdSituation + ".\n"
+  }
+  // Json Template for replying to successful volunteer messages.
+  return JSON.stringify({
+	"blocks": [
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "You signed up for <" + slackurl + "|request " + uniqueid + "> "
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "plain_text",
+                "text": "The requester's name is " + requesterName + 
+                        ".\n Their address is: " + address + 
+                        ".\n And their contact details are: " + contactDetails +
+                        householdMessage
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": ":tada:. \nWhen you are done, type `/done " + uniqueid + "`"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "To cancel your help offer, type `/cancel " + uniqueid + "`"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "To see this message again, type `/volunteer " + uniqueid + "`"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "If you need any help, contact " + mention_requestCoord + "."
+			}
+		}
+	]      
+  });
+}

--- a/slack_volunteer.gs
+++ b/slack_volunteer.gs
@@ -1,37 +1,16 @@
 function volunteer (uniqueid, channelid, userid, username){
   ///// COMMAND: /VOLUNTEER
   
-  
   /// declare variables
   var globvar = globalVariables();
   
   var mention_requestCoord = globvar['MENTION_REQUESTCOORD'];
   
-  var log_sheetname = globvar['LOG_SHEETNAME'];
-  var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
-  
+  var tracking_sheet = new TrackingSheetWrapper();
+  var log_sheet = new LogSheetWrapper();
+    
   var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
   var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
-    
-  var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
-  var tracking_sheet_ncol = tracking_sheet_col_order.length;
-  var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname  
-  
-  var UNIQUEID_START_VAL = globvar['UNIQUEID_START_VAL'];
-  var UNIQUEID_START_ROWINDEX = globvar['UNIQUEID_START_ROWINDEX'];
-  
-  var colindex_uniqueid = tracking_sheet_col_index['uniqueid'];
-  var colindex_channelid = tracking_sheet_col_index['channelid']; 
-  var colindex_phone = tracking_sheet_col_index['requesterContact'];
-  var colindex_status = tracking_sheet_col_index['requestStatus']; 
-  var colindex_volunteerName = tracking_sheet_col_index['slackVolunteerName']; 
-  var colindex_volunteerID = tracking_sheet_col_index['slackVolunteerID']; 
-  var colindex_slackts = tracking_sheet_col_index['slackTS']; 
-  var colindex_slacktsurl = tracking_sheet_col_index['slackURL'];
-  var colindex_channel = tracking_sheet_col_index['channel']; 
-  var colindex_requestername = tracking_sheet_col_index['requesterName'];
-  var colindex_address = tracking_sheet_col_index['requesterAddr'];
-  
   
   
   // check that request uniqueid has been specified
@@ -46,54 +25,38 @@ function volunteer (uniqueid, channelid, userid, username){
                                            'Please specify a correct request number. Example: `/volunteer 1000`.');
   }
   
-  // load sheet
-  var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-  var sheet = spreadsheet.getSheetByName(tracking_sheetname);
-  
   // find requested row in sheet
-  var row = getRowByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
-  var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
-  if (rowvalues[colindex_uniqueid] != uniqueid){
-    if (rowvalues[colindex_uniqueid] == ''){ // uniqueid points to empty row --> suggests wrong number was entered
+  var row = tracking_sheet.getRowByUniqueID(uniqueid);
+  if (row.uniqueid != uniqueid){
+    if (row.uniqueid == ''){ // uniqueid points to empty row --> suggests wrong number was entered
       return ContentService.createTextOutput('error: I couldn\'t find the request number `' + uniqueid + '`. Did you type the right number? '+
                                              'Type `/list` to list all the available requests in this channel. If the issue persists, contact ' + mention_requestCoord + '.');
     } else { // uniqueid points to non-empty row but mismatch --> this is a spreadsheet issue. suggests rows are not sorted by uniqueid.
-    return ContentService.createTextOutput('error: Request number lookup failed on server end. Please notify ' + mention_requestCoord);
+      return ContentService.createTextOutput('error: Request number lookup failed on server end. Please notify ' + mention_requestCoord);
     }
   }
-  
-  // store fields as separate variables
-  var channelid_true = rowvalues[colindex_channelid]; 
-  var requesterName = rowvalues[colindex_requestername];
-  var address = rowvalues[colindex_address];
-  var slackurl = rowvalues[colindex_slacktsurl];
-  var status = rowvalues[colindex_status]; 
-  var volunteerID = rowvalues[colindex_volunteerID];
-  var slack_ts = rowvalues[colindex_slackts];
-  var contactDetails = rowvalues[colindex_phone];   // private data
-  
     
   // check that request belongs to the channel from which /volunteer message was sent  
-  if (channelid != channelid_true) {
+  if (channelid != row.channelid) {
     return ContentService.createTextOutput('error: The request ' + uniqueid + ' does not appear to belong to the channel you are writing from. '+
                                            'Type `/list` to list all the available requests in this channel. If the issue persists, contact ' + mention_requestCoord + '.');
   }
    
   // manage scenario where request is no longer available (status is not {"" or "Sent"} or volunteerID!='') 
-  if ((status != "" && status != "Sent") || volunteerID != "") {
-    if (status == "Closed"){
-      return ContentService.createTextOutput('error: <' + slackurl + '|Request ' + uniqueid + '> (' + requesterName + ', ' + address + ') is closed. '+
-                                             'The volunteer assigned was <@' + volunteerID + '>. Type `/list` to list all the available requests in this channel. '+
+  if ((row.requestStatus != "" && row.requestStatus != "Sent") || row.slackVolunteerID != "") {
+    if (row.requestStatus == "Closed"){
+      return ContentService.createTextOutput('error: <' + row.slackURL + '|Request ' + uniqueid + '> (' + row.requesterName + ', ' + stripStartingNumbers(row.requesterAddr) + ') is closed. '+
+                                             'The volunteer assigned was <@' + row.slackVolunteerID + '>. Type `/list` to list all the available requests in this channel. '+
                                              'If you think there is a mistake, contact ' + mention_requestCoord + '.');
     }
-    else if ((status == "Assigned" || status == "Ongoing") && volunteerID == userid){
-      return ContentService.createTextOutput(':nerd_face: You are still signed up for <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '). '+
-                                             'The Requester\'s contact details are ' + contactDetails + ':tada:.\nWhen you are done, type `/done ' + uniqueid + '`.\n'+
+    else if ((row.requestStatus == "Assigned" || row.requestStatus == "Ongoing") && row.slackVolunteerID == userid){
+      return ContentService.createTextOutput(':nerd_face: You are still signed up for <' + row.slackURL + '|request ' + uniqueid + '> (' + row.requesterName + ', ' + row.requesterAddr + '). '+
+                                             'The Requester\'s contact details are ' + row.requesterContact + ':tada:.\nWhen you are done, type `/done ' + uniqueid + '`.\n'+
                                              'To cancel your help offer, type `/cancel '+ uniqueid + '`.\nTo see this message again, type `/volunteer ' + uniqueid + '`.\n'+
                                              'If you need any help, contact ' + mention_requestCoord + '.');
     } else {
-      return ContentService.createTextOutput('Sorry, <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + ') is not available. Its status is ' + status + '. '+
-                                             'Volunteer is <@' + volunteerID + '>. Type `/list` to list all the available requests in this channel. '+
+      return ContentService.createTextOutput('Sorry, <' + row.slackURL + '|request ' + uniqueid + '> (' + row.requesterName + ', ' + stripStartingNumbers(row.requesterAddr) + ') is not available. Its status is ' + row.requestStatus + '. '+
+                                             'Volunteer is <@' + row.slackVolunteerID + '>. Type `/list` to list all the available requests in this channel. '+
                                              'If you think there is a mistake, contact ' + mention_requestCoord + '.');
     }
   }
@@ -106,7 +69,7 @@ function volunteer (uniqueid, channelid, userid, username){
       contentType: 'application/json; charset=utf-8',
       headers: {Authorization: 'Bearer ' + access_token},
       payload: JSON.stringify({text: out_message,
-                               thread_ts: slack_ts,
+                               thread_ts: row.slackTS,
                                channel: channelid})
     };
   // Send post request to Slack chat.postMessage API   
@@ -117,30 +80,33 @@ function volunteer (uniqueid, channelid, userid, username){
   if (return_params.ok !== true){ // message was not successfully posted to channel
     
     // update log sheet
-    var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-    var row_log = sheet_log.getLastRow();
-    sheet_log.getRange(row_log+1,1,1,5).setValues([[new Date(), uniqueid,'admin','confirmVolunteer',return_message]]);
+    log_sheet.appendRow([new Date(), uniqueid,'admin','confirmVolunteer',return_message]);
     
     // return error to user
     return ContentService.createTextOutput('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to sign you up manually?');
   }
   
   // write userid, username and status to sheet
-  sheet.getRange(row, colindex_volunteerID+1).setValue(userid);
-  sheet.getRange(row, colindex_volunteerName+1).setValue(username);
-  sheet.getRange(row, colindex_status+1).setValue('Assigned');
+  row.slackVolunteerID = userid;
+  row.slackVolunteerName = username;
+  row.requestStatus = "Assigned";
+  tracking_sheet.writeRow(row);
   
   // update log sheet
-  var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-  var row_log = sheet_log.getLastRow();
-  sheet_log.getRange(row_log+1,1,2,5).setValues([[new Date(), uniqueid,userid,'slackCommand','volunteer'],
-                                                 [new Date(), uniqueid,'admin','confirmVolunteer',return_message]]);
-    
+  log_sheet.appendRow([new Date(), uniqueid,userid,'slackCommand','volunteer']);
+  log_sheet.appendRow([new Date(), uniqueid, 'admin','confirmVolunteer', return_message]);   
 
-  return ContentService.createTextOutput(':nerd_face: Thank you for volunteering! You signed up for <' + slackurl + '|request ' + uniqueid + '> (' + requesterName + ', ' + address + '). '+
-                                         'The Requester\'s contact details are ' + contactDetails + ':tada:.\nWhen you are done, type `/done ' + uniqueid + '`.\n'+
-                                         'To cancel your help offer, type `/cancel '+ uniqueid + '`.\nTo see this message again, type `/volunteer ' + uniqueid + '`.\n'+
-                                         'If you need any help, contact ' + mention_requestCoord + '.');
+  return contentServerJsonReply(
+    // Function signiture: slackurl, uniqueid, requesterName, mention_requestCoord, address, contactDetails, householdSituation
+    volunteerSuccessReply(
+      row.slackURL, 
+      uniqueid, 
+      row.requesterName, 
+      mention_requestCoord, 
+      row.requesterAddr, 
+      row.requesterContact,
+      row.householdSit,
+    ))
 }
 
 

--- a/slack_volunteer.gs
+++ b/slack_volunteer.gs
@@ -183,7 +183,7 @@ function volunteer2 (uniqueid, channelid, userid, username){
 //     return ContentService.createTextOutput('error: I couldn\'t find the request number `' + uniqueid + '`. Did you type the right number?'+
 //  ' Type `/list` to list all the available requests in this channel. If the issue persists, contact ' + mention_requestCoord + '.');
 //  }
-  var row = getRowByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
+  var row = getRowNumberByUniqueID(uniqueid, UNIQUEID_START_VAL, UNIQUEID_START_ROWINDEX);
 //  var row = +uniqueid - 1000 +2;
   var rowvalues = sheet.getRange(row, 1, 1, tracking_sheet_ncol).getValues()[0];
   if (rowvalues[colindex_uniqueid] != uniqueid){

--- a/variables.gs
+++ b/variables.gs
@@ -39,9 +39,7 @@ function globalVariables(){
     MACHINE_WRITABLE_COLS: [
                       "commentsForSlack",
                       "requestStatus",
-                      "slackURL",
                       "slackTS",
-                      "commentsForCoordinator",
                       "slackVolunteerName",
                       "channelid",
                       "slackVolunteerID"],

--- a/variables.gs
+++ b/variables.gs
@@ -34,7 +34,17 @@ function globalVariables(){
                       "channelid",
                       "slackVolunteerID"], // tracking sheet column order. ie: first element is col 'A', second is col 'B', ... 
 //    The strings need not match the actual sheet's header strings. They must match the strings called in the script functions.
-    
+    // A list of columns that can be updated via this script.
+    // This is to prevent accidental overwritting of sheet columns.
+    MACHINE_WRITABLE_COLS: [
+                      "commentsForSlack",
+                      "requestStatus",
+                      "slackURL",
+                      "slackTS",
+                      "commentsForCoordinator",
+                      "slackVolunteerName",
+                      "channelid",
+                      "slackVolunteerID"],
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage'
   };
   return globvar;


### PR DESCRIPTION
The main changes here:
- Household situation information is passed on when someone volunteers
- Address information format is changed: it is left raw in the tracker sheet, and the house number is stripped before posting a request.
- A first attempt at adding an abstraction for reading/writing to the tracking and log sheets were added.

Sheet changes required:
- The address column of the tracking sheet (column E) needs to be changed to just reference the raw data, rather than performing regex.  (e.g. "=rawdata_import!D1" )