### PR TITLE
Feature async response form

### DIFF
--- a/handle_async.gs
+++ b/handle_async.gs
@@ -25,7 +25,8 @@ function processFunctionSync(functionName, args){
  */
 function processFunctionAsync(
   functionName, args, reply_url, immediateReturnMessage){
-  processFunctionAsyncWithTrigger(functionName, args, reply_url);
+//  processFunctionAsyncWithTrigger(functionName, args, reply_url);
+  processAsyncWithFormTrigger(functionName, args);
   return contentServerJsonReply(immediateReturnMessage);
 }
 

--- a/handle_async.gs
+++ b/handle_async.gs
@@ -23,10 +23,12 @@ function processFunctionSync(functionName, args){
  * @param {*} reply_url
  * @param {*} immediateReturnMessage
  */
-function processFunctionAsync(
-  functionName, args, reply_url, immediateReturnMessage){
-//  processFunctionAsyncWithTrigger(functionName, args, reply_url);
-  processAsyncWithFormTrigger(functionName, args);
+function processFunctionAsync(functionName, args, reply_url, immediateReturnMessage){
+  // Queue an async reply with the asyncMethod defined in globalVariables (i.e. either a time-based or form-based trigger)
+  var asyncMethod = globalVariables().ASYNC_METHOD;
+  GlobalFuncHandle[asyncMethod](functionName, args, reply_url);
+  
+  // Return immediate response to user
   return contentServerJsonReply(immediateReturnMessage);
 }
 

--- a/handle_async_form.gs
+++ b/handle_async_form.gs
@@ -1,8 +1,8 @@
-function processAsyncWithFormTrigger(functionName, args) {
+function processAsyncWithFormTrigger(functionName, args, reply_url) {
   // Submit request to event form, to allow a delayed response
   
   // construct post request
-  var eventForm = globalVariables()['EVENT_FORM'];  
+  var eventForm = JSON.parse(PropertiesService.getScriptProperties().getProperty('EVENT_FORM'));
   var options = {
     method:'post',
     payload:{

--- a/handle_async_form.gs
+++ b/handle_async_form.gs
@@ -1,0 +1,30 @@
+function processAsyncWithFormTrigger(functionName, args) {
+  // Submit request to event form, to allow a delayed response
+  
+  // construct post request
+  var eventForm = globalVariables()['EVENT_FORM'];  
+  var options = {
+    method:'post',
+    payload:{
+      [eventForm.entry_id.fctName]:functionName,
+      [eventForm.entry_id.args]:JSON.stringify(args)
+    }
+  };
+  
+  // Post request submission to form. The return value of .getContextText() does not appear to be informative of success of submission.
+  UrlFetchApp.fetch(eventForm.url, options).getContentText(); 
+}
+
+
+function handleEventFormSubmission(values){
+  // handle the submissions that originate specifically from the eventForm
+  
+  // extract functionName, args and response_url
+  var [timestamp, functionName, args_str] = values;
+  var args = JSON.parse(args_str);
+  var reply_url = args.response_url;
+  
+  // call processAndPostResults
+  processAndPostResults(functionName, args, reply_url);
+}
+

--- a/main.gs
+++ b/main.gs
@@ -23,7 +23,7 @@ function triggerOnFormSubmit (e){ // this is an installed trigger. see https://d
   
   
   // handle trigger depending on which form the submission originates from
-  var eventForm = globalVariables()['EVENT_FORM'];
+  var eventForm = JSON.parse(PropertiesService.getScriptProperties().getProperty('EVENT_FORM'));
   
   if (e.values.length === eventForm.values.length){ // this is a submission from the event form
     handleEventFormSubmission(e.values);

--- a/main.gs
+++ b/main.gs
@@ -16,39 +16,53 @@ function doPost(e) { // catches slack POST requests
 
 function triggerOnFormSubmit (e){ // this is an installed trigger. see https://developers.google.com/apps-script/guides/triggers/installable
   // this function is called when manual form submission occurs. We use this trigger to detect incoming help requests, and when these already have a channel specified, are directly sent to the relevant slack channel.
+  
+  
+  // check syntax
+  //**** todo ****//
+  
+  
+  // handle trigger depending on which form the submission originates from
+  var eventForm = globalVariables()['EVENT_FORM'];
+  
+  if (e.values.length === eventForm.values.length){ // this is a submission from the event form
+    handleEventFormSubmission(e.values);
+  } else{
+  
 
-
-  /// declare variables
-  var globvar = globalVariables();
-
-  var log_sheetname = globvar['LOG_SHEETNAME'];
-  var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
-
-  var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
-  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
-
-  var formindex_channel = globvar['FORMINDEX_CHANNEL']; // channel form submit index
-  var sheet_row_offset = globvar['SHEET_ROW_OFFSET']; // relative row offset between form response sheet and tracking sheet
-
-  var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
-  var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname
-
-
-  // retrieve relevant information from onFormSubmit trigger event
-  var channel = e.values[formindex_channel];
-  var row_response = e.range.rowStart; // row where submission is in response sheet
-  var row = row_response + sheet_row_offset; // row where submission is in tracking sheet, taking any potential row offset between sheets into account.
-
-  if (channel !== ''){ // if channel was specified in form submission, send request directly to slack channel
-
-    // call sheets
-    var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-    var sheet = spreadsheet.getSheetByName(tracking_sheetname);
-    var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-
-    // post message to slack and update sheets
-    postRequest(sheet, row, tracking_sheet_col_index, webhook_chatPostMessage, access_token, 'dispatchNew', sheet_log);
-
+    /// declare variables
+    var globvar = globalVariables();
+    
+    var log_sheetname = globvar['LOG_SHEETNAME'];
+    var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
+    
+    var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
+    var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
+    
+    var formindex_channel = globvar['FORMINDEX_CHANNEL']; // channel form submit index
+    var sheet_row_offset = globvar['SHEET_ROW_OFFSET']; // relative row offset between form response sheet and tracking sheet
+    
+    var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
+    var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname
+    
+    
+    // retrieve relevant information from onFormSubmit trigger event
+    var channel = e.values[formindex_channel];
+    var row_response = e.range.rowStart; // row where submission is in response sheet
+    var row = row_response + sheet_row_offset; // row where submission is in tracking sheet, taking any potential row offset between sheets into account.
+    
+    if (channel && channel !== ''){ // if channel was specified in form submission, send request directly to slack channel
+      
+      // call sheets
+      var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+      var sheet = spreadsheet.getSheetByName(tracking_sheetname);
+      var sheet_log = spreadsheet.getSheetByName(log_sheetname);
+      
+      // post message to slack and update sheets
+      postRequest(sheet, row, tracking_sheet_col_index, webhook_chatPostMessage, access_token, 'dispatchNew', sheet_log);
+      
+    }
+    
   }
 
 

--- a/slack_messages.gs
+++ b/slack_messages.gs
@@ -113,10 +113,10 @@ var postToSlack = function(message, url){
                      .getProperty('ACCESS_TOKEN');
 
   var options = {
-      method: "post",
-      contentType: 'application/json; charset=utf-8',
-      headers: {Authorization: 'Bearer ' + access_token},
-      payload: JSON.stringify(message)
+    method: "post",
+    contentType: 'application/json; charset=utf-8',
+    headers: {Authorization: 'Bearer ' + access_token},
+    payload: message
   };
 
   return UrlFetchApp

--- a/variables.gs
+++ b/variables.gs
@@ -81,25 +81,19 @@ function globalVariables(){
     // Functions that are to be processed async
     ASYNC_FUNCTIONS: [
       'volunteer',
-      // 'assign',
+      'assign',
       'cancel',
-      // 'list',
-      // 'list_active',
-      // 'listall',
-      // 'listmine',
-      // 'listallmine',
-      // 'done_process_modal',
+      'list',
+      'list_active',
+      'listall',
+      'listmine',
+      'listallmine',
+      'done_process_modal',
     ],
-    
-    // Information required to make POST requests to the event form used for async responses, and handle the events it triggers
-    EVENT_FORM: {
-      url:'https://docs.google.com/forms/u/0/d/e/1FAIpQLSdLD_pYmxUeWjabxXefEbU1r3pTIBfQFkpT4jvUqdGaMCrUYQ/formResponse',
-      entry_id:{
-        fctName:'entry.143767227',
-        args:'entry.1157732105'
-      },
-      values:["timestamp","function","args"] // structure of the event.values object sent to the onFormSubmit function
-    },
+      
+      // Which method should be used for delayed reponses?
+//      ASYNC_METHOD:"processFunctionAsyncWithTrigger", // time-based trigger
+      ASYNC_METHOD:"processAsyncWithFormTrigger", // form-based trigger
 
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage',
     WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral',

--- a/variables.gs
+++ b/variables.gs
@@ -90,6 +90,16 @@ function globalVariables(){
       // 'listallmine',
       // 'done_process_modal',
     ],
+    
+    // Information required to make POST requests to the event form used for async responses, and handle the events it triggers
+    EVENT_FORM: {
+      url:'https://docs.google.com/forms/u/0/d/e/1FAIpQLSdLD_pYmxUeWjabxXefEbU1r3pTIBfQFkpT4jvUqdGaMCrUYQ/formResponse',
+      entry_id:{
+        fctName:'entry.143767227',
+        args:'entry.1157732105'
+      },
+      values:["timestamp","function","args"] // structure of the event.values object sent to the onFormSubmit function
+    },
 
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage',
     WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral',


### PR DESCRIPTION
A separate "event form" is used as a stack for async responses.
Response time within seconds on 4-5 tests.

Steps to reproduce: 
- create a form with two fields (first expects functionName, second expects args)
- link form to the container spreadsheet
- update globalVariable().EVENT_FORM with the correct url and entry_id values (inspect "send" form http page to find these).