### PR TITLE
Fix slack message formatting

### DIFF
--- a/handle_async.gs
+++ b/handle_async.gs
@@ -25,7 +25,8 @@ function processFunctionSync(functionName, args){
  */
 function processFunctionAsync(
   functionName, args, reply_url, immediateReturnMessage){
-  processFunctionAsyncWithTrigger(functionName, args, reply_url);
+//  processFunctionAsyncWithTrigger(functionName, args, reply_url);
+  processAsyncWithFormTrigger(functionName, args);
   return contentServerJsonReply(immediateReturnMessage);
 }
 

--- a/handle_async_form.gs
+++ b/handle_async_form.gs
@@ -1,0 +1,30 @@
+function processAsyncWithFormTrigger(functionName, args) {
+  // Submit request to event form, to allow a delayed response
+  
+  // construct post request
+  var eventForm = globalVariables()['EVENT_FORM'];  
+  var options = {
+    method:'post',
+    payload:{
+      [eventForm.entry_id.fctName]:functionName,
+      [eventForm.entry_id.args]:JSON.stringify(args)
+    }
+  };
+  
+  // Post request submission to form. The return value of .getContextText() does not appear to be informative of success of submission.
+  UrlFetchApp.fetch(eventForm.url, options).getContentText(); 
+}
+
+
+function handleEventFormSubmission(values){
+  // handle the submissions that originate specifically from the eventForm
+  
+  // extract functionName, args and response_url
+  var [timestamp, functionName, args_str] = values;
+  var args = JSON.parse(args_str);
+  var reply_url = args.response_url;
+  
+  // call processAndPostResults
+  processAndPostResults(functionName, args, reply_url);
+}
+

--- a/main.gs
+++ b/main.gs
@@ -16,39 +16,53 @@ function doPost(e) { // catches slack POST requests
 
 function triggerOnFormSubmit (e){ // this is an installed trigger. see https://developers.google.com/apps-script/guides/triggers/installable
   // this function is called when manual form submission occurs. We use this trigger to detect incoming help requests, and when these already have a channel specified, are directly sent to the relevant slack channel.
+  
+  
+  // check syntax
+  //**** todo ****//
+  
+  
+  // handle trigger depending on which form the submission originates from
+  var eventForm = globalVariables()['EVENT_FORM'];
+  
+  if (e.values.length === eventForm.values.length){ // this is a submission from the event form
+    handleEventFormSubmission(e.values);
+  } else{
+  
 
-
-  /// declare variables
-  var globvar = globalVariables();
-
-  var log_sheetname = globvar['LOG_SHEETNAME'];
-  var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
-
-  var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
-  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
-
-  var formindex_channel = globvar['FORMINDEX_CHANNEL']; // channel form submit index
-  var sheet_row_offset = globvar['SHEET_ROW_OFFSET']; // relative row offset between form response sheet and tracking sheet
-
-  var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
-  var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname
-
-
-  // retrieve relevant information from onFormSubmit trigger event
-  var channel = e.values[formindex_channel];
-  var row_response = e.range.rowStart; // row where submission is in response sheet
-  var row = row_response + sheet_row_offset; // row where submission is in tracking sheet, taking any potential row offset between sheets into account.
-
-  if (channel !== ''){ // if channel was specified in form submission, send request directly to slack channel
-
-    // call sheets
-    var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-    var sheet = spreadsheet.getSheetByName(tracking_sheetname);
-    var sheet_log = spreadsheet.getSheetByName(log_sheetname);
-
-    // post message to slack and update sheets
-    postRequest(sheet, row, tracking_sheet_col_index, webhook_chatPostMessage, access_token, 'dispatchNew', sheet_log);
-
+    /// declare variables
+    var globvar = globalVariables();
+    
+    var log_sheetname = globvar['LOG_SHEETNAME'];
+    var tracking_sheetname = globvar['TRACKING_SHEETNAME'];
+    
+    var webhook_chatPostMessage = globvar['WEBHOOK_CHATPOSTMESSAGE'];
+    var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
+    
+    var formindex_channel = globvar['FORMINDEX_CHANNEL']; // channel form submit index
+    var sheet_row_offset = globvar['SHEET_ROW_OFFSET']; // relative row offset between form response sheet and tracking sheet
+    
+    var tracking_sheet_col_order = globvar['SHEET_COL_ORDER'];
+    var tracking_sheet_col_index = indexedObjectFromArray(tracking_sheet_col_order); // make associative object to easily get colindex from colname
+    
+    
+    // retrieve relevant information from onFormSubmit trigger event
+    var channel = e.values[formindex_channel];
+    var row_response = e.range.rowStart; // row where submission is in response sheet
+    var row = row_response + sheet_row_offset; // row where submission is in tracking sheet, taking any potential row offset between sheets into account.
+    
+    if (channel && channel !== ''){ // if channel was specified in form submission, send request directly to slack channel
+      
+      // call sheets
+      var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+      var sheet = spreadsheet.getSheetByName(tracking_sheetname);
+      var sheet_log = spreadsheet.getSheetByName(log_sheetname);
+      
+      // post message to slack and update sheets
+      postRequest(sheet, row, tracking_sheet_col_index, webhook_chatPostMessage, access_token, 'dispatchNew', sheet_log);
+      
+    }
+    
   }
 
 

--- a/slack_done.gs
+++ b/slack_done.gs
@@ -94,38 +94,6 @@ function done_send_modal(args){
 }
 
 
-function done_process_modal(args){
-  /// done_process_modal: Read done modal submission. Process done command.
-
-  /// declare variables
-  var globvar = globalVariables();
-  var access_token = PropertiesService.getScriptProperties().getProperty('ACCESS_TOKEN'); // confidential Slack API access token
-
-  // process done command
-  var out_message = done(args);
-
-  // send reply to slack user with response_url functionality
-  var response_url = args.response_url;
-  var options = {
-    method: "post",
-    contentType: 'application/json; charset=utf-8',
-    headers: {Authorization: 'Bearer ' + access_token},
-    payload: JSON.stringify({
-      "text": out_message,
-      "response_type": "ephemeral"
-    })
-  };
-  var return_message = UrlFetchApp.fetch(response_url, options).getContentText(); // Send post request to Slack response_url
-
-  // update log sheet
-  var log_sheet = new LogSheetWrapper();
-  log_sheet.appendRow([new Date(), args.uniqueid, 'admin','confirmDoneUser', return_message]);
-
-  return ""; // Return empty string to close modal
-}
-
-
-
 function done(args){
   ///// COMMAND: /DONE
 
@@ -157,7 +125,7 @@ function done(args){
   // check command validity
   var cmd_check = checkCommandValidity('done',row,uniqueid,userid,channelid);
   if (!cmd_check.code){ // if command check returns error status, halt function and return error message to user
-    return cmd_check.msg;
+    return textToJsonBlocks(cmd_check.msg);
   }
 
   // reply to slack thread to confirm done instance (chat.postMessage method)
@@ -181,7 +149,7 @@ function done(args){
     log_sheet.appendRow([new Date(), uniqueid,'admin','confirmDone',return_message]);
 
     // return error to user
-    return ('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to close the request manually?');
+    return textToJsonBlocks('error: Due to a technical incident, I was unable to process your command. Can you please ask ' + mention_requestCoord + ' to close the request manually?');
   }
 
   // update log sheet
@@ -204,6 +172,6 @@ function done(args){
   }
 
   // return private message to user
-  return(cmd_check.msg);
+  return textToJsonBlocks(cmd_check.msg);
 
 }

--- a/slack_messages.gs
+++ b/slack_messages.gs
@@ -113,10 +113,10 @@ var postToSlack = function(message, url){
                      .getProperty('ACCESS_TOKEN');
 
   var options = {
-      method: "post",
-      contentType: 'application/json; charset=utf-8',
-      headers: {Authorization: 'Bearer ' + access_token},
-      payload: JSON.stringify(message)
+    method: "post",
+    contentType: 'application/json; charset=utf-8',
+    headers: {Authorization: 'Bearer ' + access_token},
+    payload: message
   };
 
   return UrlFetchApp

--- a/slack_volunteer.gs
+++ b/slack_volunteer.gs
@@ -25,7 +25,7 @@ function volunteer (args){
   // check command validity
   var cmd_check = checkCommandValidity('volunteer',row,uniqueid,userid,channelid);
   if (!cmd_check.code){ // if command check returns error status, halt function and return error message to user
-    return cmd_check.msg;
+    return textToJsonBlocks(cmd_check.msg); // this return is problematic because it is a mix of block (success reply) and non-block values
   }
 
   // reply to slack thread to confirm volunteer sign-up (chat.postMessage method)
@@ -63,7 +63,7 @@ function volunteer (args){
   log_sheet.appendRow([new Date(), uniqueid, 'admin','confirmVolunteer', return_message]);
 
   // return private message to user
-  return cmd_check.msg;
+  return (cmd_check.msg); // success reply is already in blocks
 }
 
 

--- a/slack_wrapper.gs
+++ b/slack_wrapper.gs
@@ -258,7 +258,11 @@ class SlackEventWrapper {
     // Process Command
     if (globalVariables()["ASYNC_FUNCTIONS"].indexOf(fctName) != -1){
       // Handle Asyc
+      if(this.subtype==='done_modal'){
+        var immediateReturnMessage = null; // modal requires a blank HTTP 200 OK immediate response to close
+      } else{
       var immediateReturnMessage = "Thank you for your message. I\'m a poor bot so please be patient... it should take me up to a few minutes to get back to you...";
+      }
       var reply_url = this.args.response_url;
       return processFunctionAsync(
         fctName, this.args, reply_url, immediateReturnMessage);

--- a/variables.gs
+++ b/variables.gs
@@ -90,6 +90,16 @@ function globalVariables(){
       // 'listallmine',
       // 'done_process_modal',
     ],
+    
+    // Information required to make POST requests to the event form used for async responses, and handle the events it triggers
+    EVENT_FORM: {
+      url:'https://docs.google.com/forms/u/0/d/e/1FAIpQLSdLD_pYmxUeWjabxXefEbU1r3pTIBfQFkpT4jvUqdGaMCrUYQ/formResponse',
+      entry_id:{
+        fctName:'entry.143767227',
+        args:'entry.1157732105'
+      },
+      values:["timestamp","function","args"] // structure of the event.values object sent to the onFormSubmit function
+    },
 
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage',
     WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral',

--- a/variables.gs
+++ b/variables.gs
@@ -58,9 +58,9 @@ function globalVariables(){
 
     // A key-value object to associate slack command strings to the internal function name they should call
     SLACKCMD_TO_FUNCTIONNAME: {
-      'done_modal':'done_process_modal',
+      'done_modal':'done',
       '/_volunteer':'volunteer',
-      '/_volunteer2':'volunteer_debug',
+//      '/_volunteer2':'volunteer_debug',
       '/_assign':'assign',
       '/_cancel':'cancel',
       '/_done':'done_send_modal',
@@ -81,22 +81,23 @@ function globalVariables(){
     // Functions that are to be processed async
     ASYNC_FUNCTIONS: [
       'volunteer',
-      // 'assign',
+      'assign',
       'cancel',
-      // 'list',
-      // 'list_active',
-      // 'listall',
-      // 'listmine',
-      // 'listallmine',
-      // 'done_process_modal',
+      'list',
+      'list_active',
+      'listall',
+      'listmine',
+      'listallmine',
+      //'done_send_modal',
+      'done'
     ],
     
     // Information required to make POST requests to the event form used for async responses, and handle the events it triggers
     EVENT_FORM: {
-      url:'https://docs.google.com/forms/u/0/d/e/1FAIpQLSdLD_pYmxUeWjabxXefEbU1r3pTIBfQFkpT4jvUqdGaMCrUYQ/formResponse',
+      url:'https://docs.google.com/forms/u/0/d/e/1FAIpQLSdGMwONXZ-4BOWPUGvFpu47IenfKhDIpksV-g9YSm771GiGXg/formResponse',
       entry_id:{
-        fctName:'entry.143767227',
-        args:'entry.1157732105'
+        fctName:'entry.1743825050',
+        args:'entry.748121704'
       },
       values:["timestamp","function","args"] // structure of the event.values object sent to the onFormSubmit function
     },


### PR DESCRIPTION
This is unfinished work. I believe there is only one actual message formatting bug still to fix (see below) but the code's a bit messy.

In the code's current state, if a user types `/_volunteer` on a request they are already assigned to, the message formatting is wrong: `textToJsonBlocks(volunteerSuccessReply(...))` is one block too many.
I can't think of a fix for that which wouldn't involve refactoring to some larger degree.

@ijmbarr do you think you could make a fix for this?