### PR TITLE
Feature add volunteer button

### DIFF
--- a/commands.gs
+++ b/commands.gs
@@ -431,9 +431,9 @@ class DoneCommand extends Command {
     // check optional argument isn't empty or undefined
     if (
       modalResponseVals.completionLastDetails && 
-      modalResponseVals.requestNextStatus.requestNextStatusVal &&
-      modalResponseVals.requestNextStatus.requestNextStatusVal.selected_option &&
-      modalResponseVals.requestNextStatus.requestNextStatusVal.selected_option.value
+      modalResponseVals.completionLastDetails.completionLastDetailsVal &&
+      modalResponseVals.completionLastDetails.completionLastDetailsVal.selected_option &&
+      modalResponseVals.completionLastDetails.completionLastDetailsVal.selected_option.value
     ){
       this.completionLastDetails = modalResponseVals.completionLastDetails.completionLastDetailsVal.value;
     } else{

--- a/commands.gs
+++ b/commands.gs
@@ -250,6 +250,17 @@ class VolunteerCommand extends Command {
   
   notify(){
     
+    // slack channel chat.update messenger
+    // updates postRequest message to no longer have the "volunteer" button
+    var payload = postRequestMessage(this.row,false);
+    var channelMessenger = new SlackChannelUpdateMessenger(this);
+    var return_message = channelMessenger.send(payload);
+    
+    // halt if message was not successfully sent
+    if (JSON.parse(return_message).ok !== true){
+      throw new Error(postToSlackChannelErrorMessage());
+    }
+    
     // slack channel messenger
     var payload = volunteerChannelMessage(this.row);
     var channelMessenger = new SlackChannelMessenger(this);
@@ -302,6 +313,17 @@ class CancelCommand extends Command {
   }
   
   notify(){
+    
+    // slack channel chat.update messenger
+    // updates postRequest message to regain the "volunteer" button
+    var payload = postRequestMessage(this.row,true);
+    var channelMessenger = new SlackChannelUpdateMessenger(this);
+    var return_message = channelMessenger.send(payload);
+    
+    // halt if message was not successfully sent
+    if (JSON.parse(return_message).ok !== true){
+      throw new Error(postToSlackChannelErrorMessage());
+    }
     
     // slack channel messenger
     var payload = cancelChannelMessage(this.row,this.slackVolunteerID_old);                                                                                                           

--- a/functions.gs
+++ b/functions.gs
@@ -39,6 +39,7 @@ var textToJsonBlocks = function(text, ephemeral=true, type="mrkdwn"){
 
   if (ephemeral){
     blocks["response_type"] = "ephemeral";
+    blocks["replace_original"] = false;
   }
 
   return JSON.stringify(blocks);

--- a/functions.gs
+++ b/functions.gs
@@ -82,3 +82,21 @@ function formatDate(date) {
     return dt.getDate() + '/' + (dt.getMonth() + 1) +'/'+ dt.getFullYear( ); // DD/MM/YYYY
   }
 }
+
+var tryParseJSON = function(jsonString){
+  // from https://stackoverflow.com/questions/3710204/how-to-check-if-a-string-is-a-valid-json-string-in-javascript-without-using-try
+    try {
+        var o = JSON.parse(jsonString);
+
+        // Handle non-exception-throwing cases:
+        // Neither JSON.parse(false) or JSON.parse(1234) throw errors, hence the type-checking,
+        // but... JSON.parse(null) returns null, and typeof null === "object", 
+        // so we must check for that, too. Thankfully, null is falsey, so this suffices:
+        if (o && typeof o === "object") {
+            return o;
+        }
+    }
+    catch (e) { }
+
+    return false;
+};

--- a/main.gs
+++ b/main.gs
@@ -14,7 +14,7 @@ function doPost(e) { // catch HTTP POST events. see https://developers.google.co
     return contentServerJsonReply(messageToUser);
   }
   catch(errObj){
-    if (errObj instanceof TypeError  || errObj instanceof ReferenceError){
+    if (errObj instanceof TypeError  || errObj instanceof ReferenceError || errObj instanceof SyntaxError){
       // if a code error, throw the full error log
       throw errObj;
     }
@@ -29,7 +29,7 @@ function doTriggered(e){ // catch all Installed Trigger events. see https://deve
     sheetEvent.notify(message);
   }
   catch(errObj){
-    if (errObj instanceof TypeError  || errObj instanceof ReferenceError){
+    if (errObj instanceof TypeError  || errObj instanceof ReferenceError || errObj instanceof SyntaxError){
       // if a code error, throw the full error log
       throw errObj;
     }

--- a/sheetEvent.gs
+++ b/sheetEvent.gs
@@ -194,7 +194,7 @@ class EditTrackingSheetEventController extends SheetEventController {
       } 
       else {
         // for other status changes, just log the change
-        args.more = e.value;
+        args.more = {"requestStatusValue": e.value};
         this.cmd = new StatusLogCommand(args);
       }
     } 

--- a/slack_messaging.gs
+++ b/slack_messaging.gs
@@ -86,6 +86,14 @@ class SlackChannelMessenger extends SlackMessenger {
   }
 }
 
+class SlackChannelUpdateMessenger extends SlackMessenger {
+  constructor(cmd){
+    super(cmd);
+    this.url = globalVariables()['WEBHOOK_CHATUPDATE'];
+    this.loggerMessage.subtype='channelUpdate';
+  }
+}
+
 class SlackModalMessenger extends SlackMessenger {
   constructor(cmd){
     super(cmd);

--- a/slack_messaging.gs
+++ b/slack_messaging.gs
@@ -17,6 +17,7 @@ function contentServerJsonReply(message) {
  * @param {string} url
  */
 var postToSlack = function(payload, url){
+    
   if (JSON.parse(payload).as_user === true){
     var access_token = PropertiesService
                       .getScriptProperties()
@@ -74,6 +75,9 @@ class SlackUserAsyncMessenger extends SlackMessenger {
   constructor(cmd){
     super(cmd);
     this.url = this.cmd.args.response_url;
+    if (!this.url){ // if no url is specified, instantiate a VoidMessenger instead.
+      return new VoidMessenger(cmd);
+    }
     this.loggerMessage.subtype='userAsync';
   }
 }
@@ -102,3 +106,10 @@ class SlackModalMessenger extends SlackMessenger {
   }
 }
 
+class SlackAppHomeMessenger extends SlackMessenger {
+  constructor(cmd){
+    super(cmd);
+    this.url = globalVariables()['WEBHOOK_VIEWPUBLISH'];
+    this.loggerMessage.subtype='appHome';
+  }
+}

--- a/variables.gs
+++ b/variables.gs
@@ -57,6 +57,7 @@ function globalVariables(){
     
     // A key-value object to associate slack command strings to the command subclass that should be instantiated
     SUBCLASS_FROM_SLACKCMD: {
+      'button_volunteer':VolunteerCommand,
       'done_modal':DoneCommand,
       '/volunteer':VolunteerCommand,
       '/assign':AssignCommand,
@@ -105,7 +106,8 @@ function globalVariables(){
     // Slack API URLs for message sending
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage',
     WEBHOOK_CHATPOSTMODAL: 'https://slack.com/api/views.open',
-    WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral'
+    WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral',
+    WEBHOOK_CHATUPDATE: 'https://slack.com/api/chat.update'
   };
   return globvar;
 }

--- a/variables.gs
+++ b/variables.gs
@@ -59,9 +59,12 @@ function globalVariables(){
     // A key-value object to associate slack command strings to the command subclass that should be instantiated
     SUBCLASS_FROM_SLACKCMD: {
       undefined:VoidCommand,
+      'shortcut_app_home':HomeShortcutCommand,
       'app_home_opened':HomeOpenedCommand,
       'button_volunteer':VolunteerCommand,
-      'done_modal':DoneCommand,
+      'button_cancel':CancelCommand,
+      'button_done':DoneSendModalCommand,
+      'modal_done':DoneCommand,
       '/volunteer':VolunteerCommand,
       '/assign':AssignCommand,
       '/cancel':CancelCommand,
@@ -96,6 +99,8 @@ function globalVariables(){
     
     // Commands that are to be processed sync
     SYNC_COMMANDS: [
+      'shortcut_app_home',
+      'button_done',
       '/jb_d',
       '/ib_d',
       '/_done',

--- a/variables.gs
+++ b/variables.gs
@@ -7,6 +7,7 @@ function globalVariables(){
     LOG_SHEETNAME: 'log',
     TRACKING_SHEETNAME: 'tracking',
 
+    SLACK_APP_ID: 'A0131GHD0TS',
     TEAM_ID: 'T0103NU4UVA',
     MENTION_REQUESTCOORD: '<@U0108S6B96X>',
     MOD_USERID: 'U0108S6B96X',
@@ -57,6 +58,8 @@ function globalVariables(){
     
     // A key-value object to associate slack command strings to the command subclass that should be instantiated
     SUBCLASS_FROM_SLACKCMD: {
+      undefined:VoidCommand,
+      'app_home_opened':HomeOpenedCommand,
       'button_volunteer':VolunteerCommand,
       'done_modal':DoneCommand,
       '/volunteer':VolunteerCommand,
@@ -107,7 +110,8 @@ function globalVariables(){
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage',
     WEBHOOK_CHATPOSTMODAL: 'https://slack.com/api/views.open',
     WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral',
-    WEBHOOK_CHATUPDATE: 'https://slack.com/api/chat.update'
+    WEBHOOK_CHATUPDATE: 'https://slack.com/api/chat.update',
+    WEBHOOK_VIEWPUBLISH: 'https://slack.com/api/views.publish'
   };
   return globvar;
 }


### PR DESCRIPTION
**Feature summary**:
- Added volunteer, cancel and done interactive buttons.
--- Volunteer button appears in new request message posted to slack (and disappears upon a successful VolunteerCommand), or thread message posted by CancelCommand.
--- Cancel and Done buttons appear in the App Home tab (see below).

- Activated the App Home tab. It displays the user's active requests, with Cancel and Done interactive buttons.

- Added a global shortcut to the App Home tab.

- Removed slack `team_id` check in `SlackEventController.parse()` since it interferes with `SlackUrlVerificationEventController` and was not particularly useful.

- Fixed error in DoneCommand where iOS app returns undefined `completionLastDetails` if modal field is left empty.

**Modifications to slack dev app**:
- Interactive message payloads are now directed to the jb-dev container (Interactivity & Shortcuts --> Interactivity --> Request URL).
- Enabled Slack API event subscription (Event subscriptions --> Enable events). Subscribed to the `app_home_opened` event  (Event subscriptions --> Subscribe to bot events).
- Added a global shortcut (Interactivity & Shortcuts --> Shortcuts --> Create new shortcut --> callback ID: `shortcut_app_home`).