### PR TITLE
fixing code exception where completionLastDetailsVal is undefined

### DIFF
--- a/commands.gs
+++ b/commands.gs
@@ -362,8 +362,14 @@ class DoneCommand extends Command {
     // done modal responses
     var modalResponseVals = args.more;
     this.requestNextStatus = modalResponseVals.requestNextStatus.requestNextStatusVal.selected_option.value;
-    this.completionLastDetails = modalResponseVals.completionLastDetails.completionLastDetailsVal.value;
-    if (!this.completionLastDetails){
+    if (
+      modalResponseVals.completionLastDetails && 
+      modalResponseVals.completionLastDetails.completionLastDetailsVal &&
+      modalResponseVals.completionLastDetails.completionLastDetailsVal.selected_option &&
+      modalResponseVals.completionLastDetails.completionLastDetailsVal.selected_option.value
+    ){
+      this.completionLastDetails = modalResponseVals.completionLastDetails.completionLastDetailsVal.value;
+    } else{
       this.completionLastDetails=''; // replace undefined with ''
     }
   }


### PR DESCRIPTION
Latest version of ioS app doesn't send completionLastDetails in payload if text box is left empty. This causes an exception in the code if this isn't checked for. Fixed in this commit.