### PR TITLE
Merge button home features

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,0 +1,11 @@
+{
+  "timeZone": "Europe/London",
+  "dependencies": {
+  },
+  "webapp": {
+    "access": "ANYONE_ANONYMOUS",
+    "executeAs": "USER_DEPLOYING"
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
+}

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,10 +1,9 @@
 {
   "timeZone": "Europe/London",
-  "dependencies": {
-  },
+  "dependencies": {},
   "webapp": {
-    "access": "ANYONE_ANONYMOUS",
-    "executeAs": "USER_DEPLOYING"
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
   },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8"

--- a/commands.gs
+++ b/commands.gs
@@ -431,9 +431,9 @@ class DoneCommand extends Command {
     // check optional argument isn't empty or undefined
     if (
       modalResponseVals.completionLastDetails && 
-      modalResponseVals.requestNextStatus.requestNextStatusVal &&
-      modalResponseVals.requestNextStatus.requestNextStatusVal.selected_option &&
-      modalResponseVals.requestNextStatus.requestNextStatusVal.selected_option.value
+      modalResponseVals.completionLastDetails.completionLastDetailsVal &&
+      modalResponseVals.completionLastDetails.completionLastDetailsVal.selected_option &&
+      modalResponseVals.completionLastDetails.completionLastDetailsVal.selected_option.value
     ){
       this.completionLastDetails = modalResponseVals.completionLastDetails.completionLastDetailsVal.value;
     } else{

--- a/commands.gs
+++ b/commands.gs
@@ -250,6 +250,17 @@ class VolunteerCommand extends Command {
   
   notify(){
     
+    // slack channel chat.update messenger
+    // updates postRequest message to no longer have the "volunteer" button
+    var payload = postRequestMessage(this.row,false);
+    var channelMessenger = new SlackChannelUpdateMessenger(this);
+    var return_message = channelMessenger.send(payload);
+    
+    // halt if message was not successfully sent
+    if (JSON.parse(return_message).ok !== true){
+      throw new Error(postToSlackChannelErrorMessage());
+    }
+    
     // slack channel messenger
     var payload = volunteerChannelMessage(this.row);
     var channelMessenger = new SlackChannelMessenger(this);
@@ -302,6 +313,17 @@ class CancelCommand extends Command {
   }
   
   notify(){
+    
+    // slack channel chat.update messenger
+    // updates postRequest message to regain the "volunteer" button
+    var payload = postRequestMessage(this.row,true);
+    var channelMessenger = new SlackChannelUpdateMessenger(this);
+    var return_message = channelMessenger.send(payload);
+    
+    // halt if message was not successfully sent
+    if (JSON.parse(return_message).ok !== true){
+      throw new Error(postToSlackChannelErrorMessage());
+    }
     
     // slack channel messenger
     var payload = cancelChannelMessage(this.row,this.slackVolunteerID_old);                                                                                                           

--- a/commands.gs
+++ b/commands.gs
@@ -159,17 +159,13 @@ class VoidCommand extends Command {
 
 class HomeShortcutCommand extends Command {
   notify(messenger){
-    // Send post request to Slack views.open API to open a modal for user
     messenger = messenger !== undefined ? messenger : new SlackModalMessenger(this);
-    var payload = appHomeShortcutModalMessage(this.args);
-    var return_message = modalMessenger.send(payload);
-  
-    // halt if message was not successfully sent
+    
+    var return_message = messenger.send(appHomeShortcutModalMessage(this.args));
     if (JSON.parse(return_message).ok !== true){
       throw new Error(postToSlackDefaultModalErrorMessage(return_message));
     }
     
-    // user return message printer
     return defaultSendModalSuccessMessage();
   }
 }
@@ -185,19 +181,18 @@ class HomeOpenedCommand extends Command {
   }
   
   getSheetData(){
-    this.rows = this.tracking_sheet.getAllRows()
-    .filter(
+    this.rows = this.tracking_sheet.getAllRows().filter(
       // non-closed status, belongs to user
-      row => isVarInArray(row.requestStatus,['Assigned','Ongoing']) &&
-      row.slackVolunteerID === this.args.userid
+        row => (
+          isVarInArray(row.requestStatus,['Assigned','Ongoing'])
+          && row.slackVolunteerID === this.args.userid
+      )
       );
   }
   
   notify(messenger){
-    // slack app home messenger
     messenger = messenger !== undefined ? messenger : new SlackAppHomeMessenger(this);
-    var payload = appHomeMessage(this.args, this.rows);
-    var return_message = appHomeMessenger.send(payload);    
+    var return_message = messenger.send(appHomeMessage(this.args, this.rows));    
   }
 }
 

--- a/commands.gs
+++ b/commands.gs
@@ -157,6 +157,13 @@ class VoidCommand extends Command {
   execute() {}
 }
 
+
+class UrlVerificationCommand extends Command {
+  execute() {
+    return this.args.more.challenge;
+  }
+}
+
 class HomeShortcutCommand extends Command {
   notify(messenger){
     messenger = messenger !== undefined ? messenger : new SlackModalMessenger(this);

--- a/functions.gs
+++ b/functions.gs
@@ -39,6 +39,7 @@ var textToJsonBlocks = function(text, ephemeral=true, type="mrkdwn"){
 
   if (ephemeral){
     blocks["response_type"] = "ephemeral";
+    blocks["replace_original"] = false;
   }
 
   return JSON.stringify(blocks);

--- a/functions.gs
+++ b/functions.gs
@@ -82,3 +82,21 @@ function formatDate(date) {
     return dt.getDate() + '/' + (dt.getMonth() + 1) +'/'+ dt.getFullYear( ); // DD/MM/YYYY
   }
 }
+
+var tryParseJSON = function(jsonString){
+  // from https://stackoverflow.com/questions/3710204/how-to-check-if-a-string-is-a-valid-json-string-in-javascript-without-using-try
+    try {
+        var o = JSON.parse(jsonString);
+
+        // Handle non-exception-throwing cases:
+        // Neither JSON.parse(false) or JSON.parse(1234) throw errors, hence the type-checking,
+        // but... JSON.parse(null) returns null, and typeof null === "object", 
+        // so we must check for that, too. Thankfully, null is falsey, so this suffices:
+        if (o && typeof o === "object") {
+            return o;
+        }
+    }
+    catch (e) { }
+
+    return false;
+};

--- a/main.gs
+++ b/main.gs
@@ -14,7 +14,7 @@ function doPost(e) { // catch HTTP POST events. see https://developers.google.co
     return contentServerJsonReply(messageToUser);
   }
   catch(errObj){
-    if (errObj instanceof TypeError  || errObj instanceof ReferenceError){
+    if (errObj instanceof TypeError  || errObj instanceof ReferenceError || errObj instanceof SyntaxError){
       // if a code error, throw the full error log
       throw errObj;
     }
@@ -29,7 +29,7 @@ function doTriggered(e){ // catch all Installed Trigger events. see https://deve
     sheetEvent.notify(message);
   }
   catch(errObj){
-    if (errObj instanceof TypeError  || errObj instanceof ReferenceError){
+    if (errObj instanceof TypeError  || errObj instanceof ReferenceError || errObj instanceof SyntaxError){
       // if a code error, throw the full error log
       throw errObj;
     }

--- a/main.gs
+++ b/main.gs
@@ -13,6 +13,9 @@
  * @param {*} e The event object.
  */
 function doPost(e) {
+//  Logger.log(e);
+//  Logger.log(e.postData.type);
+//  Logger.log(e.postData.contents);
   try{
     var slackEvent = createSlackEvent(e);
     var messageToUser = slackEvent.handle();

--- a/main.gs
+++ b/main.gs
@@ -13,16 +13,14 @@
  * @param {*} e The event object.
  */
 function doPost(e) {
-//  Logger.log(e);
-//  Logger.log(e.postData.type);
-//  Logger.log(e.postData.contents);
   try{
     var slackEvent = createSlackEvent(e);
     var messageToUser = slackEvent.handle();
     return contentServerJsonReply(messageToUser);
   }
   catch(errObj){
-    if (errObj instanceof TypeError  || errObj instanceof ReferenceError || errObj instanceof SyntaxError){
+    if (errObj instanceof TypeError 
+      || errObj instanceof ReferenceError || errObj instanceof SyntaxError) {
       // if a code error, throw the full error log
       throw errObj;
     }
@@ -42,7 +40,8 @@ function doTriggered(e) {
     sheetEvent.notify(message);
   }
   catch(errObj){
-    if (errObj instanceof TypeError  || errObj instanceof ReferenceError || errObj instanceof SyntaxError){
+    if (errObj instanceof TypeError
+      || errObj instanceof ReferenceError || errObj instanceof SyntaxError) {
       // if a code error, throw the full error log
       throw errObj;
     }

--- a/messages.gs
+++ b/messages.gs
@@ -175,8 +175,7 @@ var postRequestMessage = function(row, volunteerable=true){
 			"text": {"type": "mrkdwn", "text": `_Request ID ${row.uniqueid}_`}
 		}
   ];
-    
-  // if the request is volunteerable, add "Volunteer" button as a last block element.
+
   if (volunteerable) {
     blocks.push({
       "type": "actions",
@@ -295,11 +294,10 @@ var doneModalMessage = function(args){
 var volunteerSuccessMessage = function(row, isFirstMessage=true) {
   var mention_requestCoord = globalVariables()['MENTION_REQUESTCOORD'];
 
-  // personalise text depending on whether this is the first time volunteer sees the message or not
   if (isFirstMessage){
-    var introTxt = ":nerd_face::tada: You signed up for <" + row.slackURL + "|request " + row.uniqueid + ">."
+    var introTxt = `:nerd_face::tada: You signed up for <${row.slackURL}|request ${row.uniqueid}>.`
   } else{
-    var introTxt = ":nerd_face::tada: You are still signed up for <" + row.slackURL + "|request " + row.uniqueid + ">."
+    var introTxt = `:nerd_face::tada: You are still signed up for <${row.slackURL}|request ${row.uniqueid}>.`
   }
   
   var blocks_header = [
@@ -317,14 +315,14 @@ var volunteerSuccessMessage = function(row, isFirstMessage=true) {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": `*Let me know when you have helped - or if you wish to cancel - on your ${appHomePageDirectionsFormatted()}.*`
+        "text": `*When you have helped - or to cancel - update the request on the <${appHomeUrl()}|dashboard>.*`
       }
     },
     {
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": `Alternatively, you can send \`/done ${row.uniqueid}\`, \`/cancel ${row.uniqueid}\` or \`/volunteer ${row.uniqueid}\` in the channel.`
+        "text": `Alternatively, you can send \`/done ${row.uniqueid}\`, \`/cancel ${row.uniqueid}\` or \`/volunteer ${row.uniqueid}\` in this channel.`
       }
     },
     {

--- a/messages.gs
+++ b/messages.gs
@@ -152,7 +152,7 @@ var postRequestMessage = function(row, volunteerable=true){
       "type": "section",
       "fields": [
         {"type": "mrkdwn", "text": "*Requester:*"},
-        {"type": "plain_text", "text": `${row.requesterName} (${row.requesterAddr})`},
+        {"type": "plain_text", "text": `${row.requesterName} (${stripStartingNumbers(row.requesterAddr)})`},
         
         {"type": "mrkdwn", "text": "*Immediate request:*"},
         {"type": "plain_text", "text": `${row.requestType} `},

--- a/sheetEvent.gs
+++ b/sheetEvent.gs
@@ -170,7 +170,7 @@ var editTrackingSheetEventAdapter = function(e) {
 
 class SheetEventController {
   constructor(cmd, messenger){
-    this.cmd = cmd !== undefined ? cmd : new VoidCommand(args = {});
+    this.cmd = cmd !== undefined ? cmd : new VoidCommand({});
     this.messenger = messenger !== undefined ? messenger : new VoidMessenger(this.cmd);
   }
   

--- a/sheetEvent.gs
+++ b/sheetEvent.gs
@@ -194,7 +194,7 @@ class EditTrackingSheetEventController extends SheetEventController {
       } 
       else {
         // for other status changes, just log the change
-        args.more = e.value;
+        args.more = {"requestStatusValue": e.value};
         this.cmd = new StatusLogCommand(args);
       }
     } 

--- a/slackEvent.gs
+++ b/slackEvent.gs
@@ -13,8 +13,8 @@
  *   https://developers.google.com/apps-script/guides/web
  */
 var createSlackEvent = function(e) {
-  var {token, teamid, type, cmd} = slackEventAdapter(e);
-  return new SlackEventController(token, teamid, type, cmd);
+  var {token, cmd} = slackEventAdapter(e);
+  return new SlackEventController(token, cmd);
 }
 
 /**
@@ -60,8 +60,6 @@ var slackModalSubmissionAdapter = function(e) {
   var metadata = JSON.parse(payload.view.private_metadata);
   return {
     token: payload.token,
-    teamid: payload.team.id,
-    type: payload.type,
     cmd: createCommandClassInstance(args = {
       cmd_name: payload.view.callback_id,
       channelid: metadata.channelid,
@@ -85,8 +83,6 @@ var slackGlobalShortcutAdapter = function(e) {
   var payload = JSON.parse(e.parameter.payload);
   return {
     token: payload.token,
-    teamid: payload.team.id,
-    type: payload.type,
     cmd: createCommandClassInstance(args = {
       cmd_name: payload.callback_id,
       channelid: null,
@@ -110,8 +106,6 @@ var slackUrlVerificationAdapter = function(e) {
   var payload = JSON.parse(e.postData.contents);
   return {
     token: payload.token,
-    teamid: null,
-    type: payload.type,
     cmd: createCommandClassInstance(args = {
       cmd_name: payload.type,
       channelid: null,
@@ -136,8 +130,6 @@ var slackHomeOpenedAdapter = function(e) {
   var payload = JSON.parse(e.postData.contents);
   return {
     token: payload.token,
-    teamid: payload.team_id,
-    type: payload.type,
     cmd: createCommandClassInstance(args = {
       cmd_name: payload.event.type,
       channelid: payload.event.channel,
@@ -163,8 +155,6 @@ var slackButtonAdapter = function(e) {
   var channel_id = payload.channel !== undefined ? payload.channel.id : null;
   return {
     token: payload.token,
-    teamid: payload.team.id,
-    type: payload.type,
     cmd: createCommandClassInstance(args = {
       cmd_name: payload.actions[0].action_id,
       channelid: channel_id,
@@ -194,8 +184,6 @@ var slackSlashCommandAdapter = function(e) {
   
   return {
     token: payload.token,
-    teamid: payload.team_id,
-    type: "command",
     cmd: createCommandClassInstance(args = {
       cmd_name: payload.command,
       channelid: payload.channel_id,
@@ -216,10 +204,8 @@ var slackSlashCommandAdapter = function(e) {
 class SlackEventController {
   // Controller for slack doPost events
   
-  constructor(token, teamid, type, cmd){    
+  constructor(token, cmd){    
     this.token = token; // Slack app verification token.
-    this.teamid = teamid; // Slack workspace id.
-    this.type = type; // Event type (slash command, interactive message, ...).
     this.cmd = cmd; // Command object.
     
     this.parse();

--- a/slackEvent.gs
+++ b/slackEvent.gs
@@ -204,26 +204,24 @@ var slackSlashCommandAdapter = function(e) {
 class SlackEventController {
   // Controller for slack doPost events
   
-  constructor(token, cmd){    
+  constructor(token, cmd) {    
     this.token = token; // Slack app verification token.
     this.cmd = cmd; // Command object.
     
-    this.parse();
+    this.check_token();
+    this.cmd.parse();
   }
   
-  parse() {
-    // Check token
-    var token_true = PropertiesService.getScriptProperties().getProperty(
-      'VERIFICATION_TOKEN'); // expected slack API verification token.
+  check_token() {
+    var token_true = PropertiesService
+      .getScriptProperties()
+      .getProperty('VERIFICATION_TOKEN'); // expected slack API verification token.
     if(!token_true){ // check that token_true has been set in script properties
       throw new Error(slackTokenNotSetInScriptMessage());
     }
     if (this.token !== token_true) {
       throw new Error(slackTokenIsIncorrectMessage(this.token));
     }
-    
-    // Parse command+args
-    this.cmd.parse();
   }
   
   handle() {

--- a/slackEvent.gs
+++ b/slackEvent.gs
@@ -53,9 +53,9 @@ var slackInteractiveMessageAdapter = function(par) {
       trigger_id: null,
       uniqueid: metadata.uniqueid,
       mention: {str: null, userid: null, username: null},
-      more: payload.view.state.values
+      more: {modalResponseValues: payload.view.state.values}
     })
-  }
+  };
 }
 
 /**

--- a/slack_messaging.gs
+++ b/slack_messaging.gs
@@ -86,6 +86,14 @@ class SlackChannelMessenger extends SlackMessenger {
   }
 }
 
+class SlackChannelUpdateMessenger extends SlackMessenger {
+  constructor(cmd){
+    super(cmd);
+    this.url = globalVariables()['WEBHOOK_CHATUPDATE'];
+    this.loggerMessage.subtype='channelUpdate';
+  }
+}
+
 class SlackModalMessenger extends SlackMessenger {
   constructor(cmd){
     super(cmd);

--- a/slack_messaging.gs
+++ b/slack_messaging.gs
@@ -17,6 +17,7 @@ function contentServerJsonReply(message) {
  * @param {string} url
  */
 var postToSlack = function(payload, url){
+    
   if (JSON.parse(payload).as_user === true){
     var access_token = PropertiesService
                       .getScriptProperties()
@@ -74,6 +75,9 @@ class SlackUserAsyncMessenger extends SlackMessenger {
   constructor(cmd){
     super(cmd);
     this.url = this.cmd.args.response_url;
+    if (!this.url){ // if no url is specified, instantiate a VoidMessenger instead.
+      return new VoidMessenger(cmd);
+    }
     this.loggerMessage.subtype='userAsync';
   }
 }
@@ -102,3 +106,10 @@ class SlackModalMessenger extends SlackMessenger {
   }
 }
 
+class SlackAppHomeMessenger extends SlackMessenger {
+  constructor(cmd){
+    super(cmd);
+    this.url = globalVariables()['WEBHOOK_VIEWPUBLISH'];
+    this.loggerMessage.subtype='appHome';
+  }
+}

--- a/tests.gs
+++ b/tests.gs
@@ -520,6 +520,8 @@ function gast_test_commands(test) {
     t.equal(cmd.row.slackTS, "new_ts", "ts is updated");
     t.equal(cmd.log_sheet.sheet.arr2d[0][1], 1000, "logs uniqueid");
     t.equal(messenger.sent[0].msg, message_expected, "correct slack message");
+    t.ok(message_expected.includes("stockwell st"), "post partial address");
+    t.notOk(message_expected.includes("1 stockwell st"), "do not post full address");
   })
   
   test("postRequest command failure", function(t) {

--- a/tests.gs
+++ b/tests.gs
@@ -85,6 +85,51 @@ var mock_slack_modalSubmit_event = function(id="modal_done") {
   }};
 }
 
+var mock_slack_shortcut_event = function(id="shortcut_app_home") {
+  // see https://api.slack.com/reference/interaction-payloads/shortcuts#message_actions
+  return {parameter: {
+    payload: JSON.stringify({
+      token: PropertiesService.getScriptProperties().getProperty('VERIFICATION_TOKEN'),
+      team: {id: globalVariables()['TEAM_ID']},
+      user: {id: ""},
+      type: "shortcut",
+      callback_id: id,
+      trigger_id: ""
+    })
+  }};
+}
+
+var mock_slack_homeOpened_event = function() {
+  // see https://api.slack.com/events/app_home_opened
+  return mock_slack_api_event({
+    type: "app_home_opened",
+    event_ts: "",
+    ts: "",
+    user: "",
+    tab: "home",
+    view: {},
+  });
+}
+
+var mock_slack_api_event = function(event_obj) {
+  // see https://api.slack.com/events-api#begin
+  return {
+    parameter: {},
+    postData: {
+      contents: JSON.stringify({
+        token: PropertiesService.getScriptProperties().getProperty('VERIFICATION_TOKEN'),
+        api_app_id: "",
+        team_id: globalVariables()['TEAM_ID'],
+        type: "event_callback",
+        event: event_obj,
+        event_id: "",
+        event_time: 0123,
+        authorizations: [{}]
+      })
+    }
+  };
+}
+
 function gast_test_positive_controls(test) {
   test('do calculation right', function (t) {
     var i = 3 + 4
@@ -192,6 +237,16 @@ function gast_test_slackEventAdapters(test) {
   test("routes modal_done", function(t) {
     var e = mock_slack_modalSubmit_event("modal_done");
     t.ok(createSlackEvent(e).cmd instanceof DoneCommand, "is DoneCommand");
+  });
+  
+  test("routes shortcut_app_home", function(t) {
+    var e = mock_slack_shortcut_event("shortcut_app_home");
+    t.ok(createSlackEvent(e).cmd instanceof HomeShortcutCommand, "is HomeShortcutCommand");
+  });
+  
+  test("routes app_home_opened", function(t) {
+    var e = mock_slack_homeOpened_event();
+    t.ok(createSlackEvent(e).cmd instanceof HomeOpenedCommand, "is HomeOpenedCommand");
   });
   
 }

--- a/tests.gs
+++ b/tests.gs
@@ -310,9 +310,17 @@ function gast_test_commands(test) {
         "1591654103.007100", "", "judefbrady", "C012HGQEJMB", "UVCNQASN6", 1,
         "10/06/2020 13:57:22", "coffee required", ""
       ],
+      [
+        1002, "14/04/2020 01:40:22", "test case 12", "", "9A mill rd",
+        "", "delivery", "16/04/2020", "", "testsrequests-jb", "",
+        "jb", "", "Assigned",
+        "https://romseymutualaid.slack.com/archives/C012HGQEJMB/p1591654103007100",
+        "1591654103.007101", "", "judefbrady", "C012HGQEJMB", "UVCNQASN6", 9,
+        "", "", ""
+      ],
     ];
   }
- 
+
   test("statusLog command", function(t) {
     var cmd = new StatusLogCommand({
       uniqueid: "1000",
@@ -329,6 +337,29 @@ function gast_test_commands(test) {
       ["1000", "test_userid", "command", "statusManualEdit", "new_status_val"],
       "logs new status"
     );
+  })
+  
+  test("home shortcut command success", function(t) {
+    var cmd = new HomeShortcutCommand({trigger_id: "TRIGGER_ID"});
+    var messenger = new MockMessenger();   
+    var message_expected = appHomeShortcutModalMessage({trigger_id: "TRIGGER_ID"});
+    var return_val_expected = defaultSendModalSuccessMessage();
+    var return_val = cmd.execute(undefined, undefined, messenger);
+    t.equal(return_val, return_val_expected, "returns success message");
+    t.equal(messenger.sent[0].msg, message_expected, "correct slack modal payload");
+  })
+  
+  test("home opened command success", function(t) {
+    var cmd = new HomeOpenedCommand({userid: "UVCNQASN6", more: {tab: "home"}});
+    var tracking_sheet = new TrackingSheetWrapper(new MockSheet(mock_tracking_array()));
+    var log_sheet = new LogSheetWrapper(new MockSheet());
+    var messenger = new MockMessenger();
+    var rows_expected = [
+      tracking_sheet.getRowByUniqueID(1001), tracking_sheet.getRowByUniqueID(1002)];
+    var message_expected = appHomeMessage({userid: "UVCNQASN6"}, rows_expected);
+    cmd.execute(tracking_sheet, log_sheet, messenger);
+    t.deepEqual(cmd.rows.map(x => x.uniqueid), ["1001", "1002"], "correct uniqueids");
+    t.equal(messenger.sent[0].msg, message_expected, "correct slack message");
   })
   
   test("postRequest command success", function(t) {

--- a/tests.gs
+++ b/tests.gs
@@ -8,7 +8,7 @@ function gast() {
   var test = new GasTap();
   
   gast_test_positive_controls(test);
-//  gast_test_doPost(test);
+  gast_test_doPost(test);
   gast_test_slackEventAdapters(test);
   gast_test_slackEvent(test);
 //  gast_test_sheetEventAdapters(test);
@@ -180,8 +180,8 @@ function gast_test_positive_controls(test) {
 }
 
 function gast_test_doPost(test) {
-  test("throws if empty par", function(t) {
-    var e = {parameter: {}};
+  test("throws if empty event", function(t) {
+    var e = {parameter: {}, postData: {contents : ""}};
     t.throws(doPost(e), "test throws");
   });
   
@@ -316,8 +316,6 @@ function gast_test_slackEvent(test) {
       try_constructor_return(
         SlackEventController,
         token = "incorrect_token_placeholder",
-        teamid = null,
-        type = null,
         cmd = new VoidCommand(args = {})
       ),
       slackTokenIsIncorrectMessage("incorrect_token_placeholder"),
@@ -328,8 +326,6 @@ function gast_test_slackEvent(test) {
   test("returns void if auth success and voidcommand", function(t) {
      slackEvent = new SlackEventController(
         token = token_true,
-        teamid = null,
-        type = null,
         cmd = new VoidCommand(args = {})
       );
       t.ok(slackEvent.handle() === undefined, "");

--- a/tests.gs
+++ b/tests.gs
@@ -130,6 +130,28 @@ var mock_slack_api_event = function(event_obj) {
   };
 }
 
+var mock_slack_button_event = function(id, value) {
+  // see https://api.slack.com/reference/interaction-payloads/block-actions
+  // https://api.slack.com/legacy/message-buttons
+  return {parameter: {
+    payload: JSON.stringify({
+      token: PropertiesService.getScriptProperties().getProperty('VERIFICATION_TOKEN'),
+      team: {id: globalVariables()['TEAM_ID']},
+      channel: {id: ""},
+      user: {id: "", name: ""},
+      type: "block_actions",
+      message: {},
+      view: {},
+      actions: [
+        {block_id: "", action_id: id, value: value}
+      ],
+      trigger_id: "",
+      response_url: ""
+    })
+  }};
+}
+
+
 function gast_test_positive_controls(test) {
   test('do calculation right', function (t) {
     var i = 3 + 4
@@ -247,6 +269,21 @@ function gast_test_slackEventAdapters(test) {
   test("routes app_home_opened", function(t) {
     var e = mock_slack_homeOpened_event();
     t.ok(createSlackEvent(e).cmd instanceof HomeOpenedCommand, "is HomeOpenedCommand");
+  });
+  
+  test("routes button_volunteer", function(t) {
+    var e = mock_slack_button_event("button_volunteer", "0000");
+    t.ok(createSlackEvent(e).cmd instanceof VolunteerCommand, "is VolunteerCommand");
+  });
+  
+  test("routes button_cancel", function(t) {
+    var e = mock_slack_button_event("button_cancel", "0000");
+    t.ok(createSlackEvent(e).cmd instanceof CancelCommand, "is CancelCommand");
+  });
+  
+  test("routes button_done", function(t) {
+    var e = mock_slack_button_event("button_done", "0000");
+    t.ok(createSlackEvent(e).cmd instanceof DoneSendModalCommand, "is DoneSendModalCommand");
   });
   
 }

--- a/variables.gs
+++ b/variables.gs
@@ -57,6 +57,7 @@ function globalVariables(){
     
     // A key-value object to associate slack command strings to the command subclass that should be instantiated
     SUBCLASS_FROM_SLACKCMD: {
+      'button_volunteer':VolunteerCommand,
       'done_modal':DoneCommand,
       '/volunteer':VolunteerCommand,
       '/assign':AssignCommand,
@@ -105,7 +106,8 @@ function globalVariables(){
     // Slack API URLs for message sending
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage',
     WEBHOOK_CHATPOSTMODAL: 'https://slack.com/api/views.open',
-    WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral'
+    WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral',
+    WEBHOOK_CHATUPDATE: 'https://slack.com/api/chat.update'
   };
   return globvar;
 }

--- a/variables.gs
+++ b/variables.gs
@@ -59,9 +59,12 @@ function globalVariables(){
     // A key-value object to associate slack command strings to the command subclass that should be instantiated
     SUBCLASS_FROM_SLACKCMD: {
       undefined:VoidCommand,
+      'shortcut_app_home':HomeShortcutCommand,
       'app_home_opened':HomeOpenedCommand,
       'button_volunteer':VolunteerCommand,
-      'done_modal':DoneCommand,
+      'button_cancel':CancelCommand,
+      'button_done':DoneSendModalCommand,
+      'modal_done':DoneCommand,
       '/volunteer':VolunteerCommand,
       '/assign':AssignCommand,
       '/cancel':CancelCommand,
@@ -96,6 +99,8 @@ function globalVariables(){
     
     // Commands that are to be processed sync
     SYNC_COMMANDS: [
+      'shortcut_app_home',
+      'button_done',
       '/jb_d',
       '/ib_d',
       '/_done',

--- a/variables.gs
+++ b/variables.gs
@@ -66,6 +66,7 @@ function globalVariables(){
     // subclass that should be instantiated.
     SUBCLASS_FROM_SLACKCMD: {
       undefined:VoidCommand,
+      'url_verification': UrlVerificationCommand,
       'shortcut_app_home':HomeShortcutCommand,
       'app_home_opened':HomeOpenedCommand,
       'button_volunteer':VolunteerCommand,
@@ -106,6 +107,7 @@ function globalVariables(){
     
     // Commands that are to be processed sync
     SYNC_COMMANDS: [
+      "url_verification",
       'shortcut_app_home',
       'button_done',
       '/jb_d',

--- a/variables.gs
+++ b/variables.gs
@@ -7,6 +7,7 @@ function globalVariables(){
     LOG_SHEETNAME: 'log',
     TRACKING_SHEETNAME: 'tracking',
 
+    SLACK_APP_ID: 'A0131GHD0TS',
     TEAM_ID: 'T0103NU4UVA',
     MENTION_REQUESTCOORD: '<@U0108S6B96X>',
     MOD_USERID: 'U0108S6B96X',
@@ -57,6 +58,8 @@ function globalVariables(){
     
     // A key-value object to associate slack command strings to the command subclass that should be instantiated
     SUBCLASS_FROM_SLACKCMD: {
+      undefined:VoidCommand,
+      'app_home_opened':HomeOpenedCommand,
       'button_volunteer':VolunteerCommand,
       'done_modal':DoneCommand,
       '/volunteer':VolunteerCommand,
@@ -107,7 +110,8 @@ function globalVariables(){
     WEBHOOK_CHATPOSTMESSAGE: 'https://slack.com/api/chat.postMessage',
     WEBHOOK_CHATPOSTMODAL: 'https://slack.com/api/views.open',
     WEBHOOK_CHATPOSTMESSAGE_EPHEMERAL: 'https://slack.com/api/chat.postEphemeral',
-    WEBHOOK_CHATUPDATE: 'https://slack.com/api/chat.update'
+    WEBHOOK_CHATUPDATE: 'https://slack.com/api/chat.update',
+    WEBHOOK_VIEWPUBLISH: 'https://slack.com/api/views.publish'
   };
   return globvar;
 }


### PR DESCRIPTION
**Feature summary**:
- Added volunteer, cancel and done interactive buttons.
--- Volunteer button appears in new request message posted to slack (and disappears upon a successful VolunteerCommand), or thread message posted by CancelCommand.
--- Cancel and Done buttons appear in the App Home tab (see below).

- Activated the App Home tab. It displays the user's active requests, with Cancel and Done interactive buttons.

- Added a global shortcut to the App Home tab.

- Removed slack `team_id` check in `SlackEventController.parse()` since it interferes with `SlackUrlVerificationEventController` and was not particularly useful.

- Fixed error in DoneCommand where iOS app returns undefined `completionLastDetails` if modal field is left empty.

**Modifications to slack dev app**:
- Enabled Slack API event subscription (Event subscriptions --> Enable events). Subscribed to the `app_home_opened` event  (Event subscriptions --> Subscribe to bot events).
- Added a global shortcut (Interactivity & Shortcuts --> Shortcuts --> Create new shortcut --> callback ID: `shortcut_app_home`).